### PR TITLE
Remove use of PTE_ADDR_MASK

### DIFF
--- a/v6.7/0002-ampere-arm64-Work-around-Ampere-Altra-erratum-82288-.patch
+++ b/v6.7/0002-ampere-arm64-Work-around-Ampere-Altra-erratum-82288-.patch
@@ -107,7 +107,7 @@ index 79ce70fbb751c..5c26ee4aa7572 100644
 +{
 +#ifdef CONFIG_ALTRA_ERRATUM_82288
 +	phys_addr_t phys = __pte_to_phys(pte);
-+	pgprot_t prot = __pgprot(pte_val(pte) & ~PTE_ADDR_MASK);
++	pgprot_t prot = __pgprot(pte_val(pte) & ~__phys_to_pte_val(__pte_to_phys(__pte(~0ull))));
 +
 +	if (static_branch_unlikely(&have_altra_erratum_82288) &&
 +	    (phys < 0x80000000 ||


### PR DESCRIPTION
v6.9 removes PTE_ADDR_MASK. Replace it with
__phys_to_pte_val(__pte_to_phys(__pte(~0ull))), which is a mouthful but is still a compile time constant.

Resolves AmpereComputing/linux-ampere-altra-erratum-pcie-65#1