### PR TITLE
Move pci quirk slightly up in the quirks.c file

### DIFF
--- a/v6.7/0002-ampere-arm64-Work-around-Ampere-Altra-erratum-82288-.patch
+++ b/v6.7/0002-ampere-arm64-Work-around-Ampere-Altra-erratum-82288-.patch
@@ -107,7 +107,7 @@ index 79ce70fbb751c..5c26ee4aa7572 100644
 +{
 +#ifdef CONFIG_ALTRA_ERRATUM_82288
 +	phys_addr_t phys = __pte_to_phys(pte);
-+	pgprot_t prot = __pgprot(pte_val(pte) & ~PTE_ADDR_MASK);
++	pgprot_t prot = __pgprot(pte_val(pte) & ~__phys_to_pte_val(__pte_to_phys(__pte(~0ull))));
 +
 +	if (static_branch_unlikely(&have_altra_erratum_82288) &&
 +	    (phys < 0x80000000 ||

--- a/v6.7/0002-ampere-arm64-Work-around-Ampere-Altra-erratum-82288-.patch
+++ b/v6.7/0002-ampere-arm64-Work-around-Ampere-Altra-erratum-82288-.patch
@@ -163,11 +163,10 @@ diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
 index a2bf6de11462f..fe615fb9f4d43 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
-@@ -6243,3 +6243,12 @@ static void pci_fixup_d3cold_delay_1sec(struct pci_dev *pdev)
- 	pdev->d3cold_delay = 1000;
- }
- DECLARE_PCI_FIXUP_FINAL(0x5555, 0x0004, pci_fixup_d3cold_delay_1sec);
-+
+@@ -6212,6 +6212,15 @@ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_XILINX, 0x5020, of_pci_make_dev_node);
+ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_XILINX, 0x5021, of_pci_make_dev_node);
+ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_REDHAT, 0x0005, of_pci_make_dev_node);
+ 
 +#ifdef CONFIG_ALTRA_ERRATUM_82288
 +static void quirk_altra_erratum_82288(struct pci_dev *dev)
 +{
@@ -176,6 +175,10 @@ index a2bf6de11462f..fe615fb9f4d43 100644
 +}
 +DECLARE_PCI_FIXUP_EARLY(PCI_VENDOR_ID_AMPERE, 0xe100, quirk_altra_erratum_82288);
 +#endif
++
+ /*
+  * Devices known to require a longer delay before first config space access
+  * after reset recovery or resume from D3cold:
 -- 
 2.43.0
 


### PR DESCRIPTION
Having the quirk at the bottom will show lots of conflicts as new quirks
are added upstream. The quirk is moved up just before the last one in v6.7.

Resolves AmpereComputing/linux-ampere-altra-erratum-pcie-65#2