### PR TITLE
Add patches based on v6.12

### DIFF
--- a/v6.12/0001-ampere-arm64-Add-a-fixup-handler-for-alignment-fault.patch
+++ b/v6.12/0001-ampere-arm64-Add-a-fixup-handler-for-alignment-fault.patch
@@ -1,0 +1,1 @@
+../v6.7/0001-ampere-arm64-Add-a-fixup-handler-for-alignment-fault.patch

--- a/v6.12/0002-ampere-arm64-Work-around-Ampere-Altra-erratum-82288-.patch
+++ b/v6.12/0002-ampere-arm64-Work-around-Ampere-Altra-erratum-82288-.patch
@@ -1,0 +1,184 @@
+From c9933aba022a60ff2b6e54b256e33c82e6474f3a Mon Sep 17 00:00:00 2001
+From: D Scott Phillips <scott@os.amperecomputing.com>
+Date: Tue, 13 Feb 2024 11:08:06 -0800
+Subject: [PATCH 2/2] ampere/arm64: Work around Ampere Altra erratum #82288
+ PCIE_65
+
+Altra's PCIe controller may generate incorrect addresses when receiving
+writes from the CPU with a discontiguous set of byte enables. Attempt to
+work around this by handing out Device-nGnRE maps instead of Normal
+Non-cacheable maps for PCIe memory areas.
+
+Signed-off-by: D Scott Phillips <scott@os.amperecomputing.com>
+---
+ Documentation/arch/arm64/silicon-errata.rst |  2 ++
+ arch/arm64/Kconfig                          | 21 +++++++++++++++++
+ arch/arm64/include/asm/pci.h                |  4 ++++
+ arch/arm64/include/asm/pgtable.h            | 26 +++++++++++++++++----
+ arch/arm64/mm/ioremap.c                     | 18 ++++++++++++++
+ drivers/pci/quirks.c                        |  9 +++++++
+ 6 files changed, 75 insertions(+), 5 deletions(-)
+
+diff --git a/Documentation/arch/arm64/silicon-errata.rst b/Documentation/arch/arm64/silicon-errata.rst
+index b42fea07c5ce..793f095e6b20 100644
+--- a/Documentation/arch/arm64/silicon-errata.rst
++++ b/Documentation/arch/arm64/silicon-errata.rst
+@@ -53,6 +53,8 @@ stable kernels.
+ | Allwinner      | A64/R18         | UNKNOWN1        | SUN50I_ERRATUM_UNKNOWN1     |
+ +----------------+-----------------+-----------------+-----------------------------+
+ +----------------+-----------------+-----------------+-----------------------------+
++| Ampere         | Altra           | #82288          | ALTRA_ERRATUM_82288         |
+++----------------+-----------------+-----------------+-----------------------------+
+ | Ampere         | AmpereOne       | AC03_CPU_38     | AMPERE_ERRATUM_AC03_CPU_38  |
+ +----------------+-----------------+-----------------+-----------------------------+
+ | Ampere         | AmpereOne AC04  | AC04_CPU_10     | AMPERE_ERRATUM_AC03_CPU_38  |
+diff --git a/arch/arm64/Kconfig b/arch/arm64/Kconfig
+index a11a7a42edbf..b1f6b49e624d 100644
+--- a/arch/arm64/Kconfig
++++ b/arch/arm64/Kconfig
+@@ -456,6 +456,27 @@ config AMPERE_ERRATUM_AC03_CPU_38
+ config ARM64_WORKAROUND_CLEAN_CACHE
+ 	bool
+ 
++config ALTRA_ERRATUM_82288
++	bool "Ampere Altra: 82288: PCIE_65: PCIe Root Port outbound write combining issue"
++	default y
++	help
++	  This option adds an alternative code sequence to work around
++	  Ampere Altra erratum 82288.
++
++	  PCIe device drivers may map MMIO space as Normal, non-cacheable
++	  memory attribute (e.g. Linux kernel drivers mapping MMIO
++	  using ioremap_wc). This may be for the purpose of enabling write
++	  combining or unaligned accesses. This can result in data corruption
++	  on the PCIe interface’s outbound MMIO writes due to issues with the
++	  write-combining operation.
++
++	  The workaround modifies software that maps PCIe MMIO space as Normal,
++	  non-cacheable memory (e.g. ioremap_wc) to instead Device,
++	  non-gatheringmemory (e.g. ioremap). And all memory operations on PCIe
++	  MMIO space must be strictly aligned.
++
++	  If unsure, say Y.
++
+ config ARM64_ERRATUM_826319
+ 	bool "Cortex-A53: 826319: System might deadlock if a write cannot complete until read data is accepted"
+ 	default y
+diff --git a/arch/arm64/include/asm/pci.h b/arch/arm64/include/asm/pci.h
+index 016eb6b46dc0..050f19f1149d 100644
+--- a/arch/arm64/include/asm/pci.h
++++ b/arch/arm64/include/asm/pci.h
+@@ -18,6 +18,10 @@
+ 
+ #define arch_can_pci_mmap_wc() 1
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++extern struct static_key_false have_altra_erratum_82288;
++#endif
++
+ /* Generic PCI */
+ #include <asm-generic/pci.h>
+ 
+diff --git a/arch/arm64/include/asm/pgtable.h b/arch/arm64/include/asm/pgtable.h
+index c329ea061dc9..b711fe6cf80c 100644
+--- a/arch/arm64/include/asm/pgtable.h
++++ b/arch/arm64/include/asm/pgtable.h
+@@ -258,11 +258,6 @@ static inline pte_t pte_mkyoung(pte_t pte)
+ 	return set_pte_bit(pte, __pgprot(PTE_AF));
+ }
+ 
+-static inline pte_t pte_mkspecial(pte_t pte)
+-{
+-	return set_pte_bit(pte, __pgprot(PTE_SPECIAL));
+-}
+-
+ static inline pte_t pte_mkcont(pte_t pte)
+ {
+ 	pte = set_pte_bit(pte, __pgprot(PTE_CONT));
+@@ -708,6 +703,27 @@ static inline void set_pud_at(struct mm_struct *mm, unsigned long addr,
+ 	__pgprot_modify(prot, PTE_ATTRINDX_MASK, \
+ 			PTE_ATTRINDX(MT_NORMAL_NC) | PTE_PXN | PTE_UXN)
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++extern struct static_key_false have_altra_erratum_82288;
++#endif
++
++static inline pte_t pte_mkspecial(pte_t pte)
++{
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++	phys_addr_t phys = __pte_to_phys(pte);
++	pgprot_t prot = __pgprot(pte_val(pte) & ~__phys_to_pte_val(__pte_to_phys(__pte(~0ull))));
++
++	if (static_branch_unlikely(&have_altra_erratum_82288) &&
++	    (phys < 0x80000000 ||
++	     (phys >= 0x200000000000 && phys < 0x400000000000) ||
++	     (phys >= 0x600000000000 && phys < 0x800000000000))) {
++		pte = __pte(__phys_to_pte_val(phys) | pgprot_val(pgprot_device(prot)));
++	}
++#endif
++
++	return set_pte_bit(pte, __pgprot(PTE_SPECIAL));
++}
++
+ #define __HAVE_PHYS_MEM_ACCESS_PROT
+ struct file;
+ extern pgprot_t phys_mem_access_prot(struct file *file, unsigned long pfn,
+diff --git a/arch/arm64/mm/ioremap.c b/arch/arm64/mm/ioremap.c
+index 6cc0b7e7eb03..ed48efdd39c1 100644
+--- a/arch/arm64/mm/ioremap.c
++++ b/arch/arm64/mm/ioremap.c
+@@ -14,6 +14,19 @@ int arm64_ioremap_prot_hook_register(ioremap_prot_hook_t hook)
+ 	return 0;
+ }
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++DEFINE_STATIC_KEY_FALSE(have_altra_erratum_82288);
++
++static bool is_altra_pci(phys_addr_t phys_addr, size_t size)
++{
++	phys_addr_t end = phys_addr + size;
++
++	return (phys_addr < 0x80000000 ||
++		(end > 0x200000000000 && phys_addr < 0x400000000000) ||
++		(end > 0x600000000000 && phys_addr < 0x800000000000));
++}
++#endif
++
+ void __iomem *ioremap_prot(phys_addr_t phys_addr, size_t size,
+ 			   unsigned long prot)
+ {
+@@ -37,6 +50,11 @@ void __iomem *ioremap_prot(phys_addr_t phys_addr, size_t size,
+ 		return NULL;
+ 	}
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++	if (static_branch_unlikely(&have_altra_erratum_82288) && is_altra_pci(phys_addr, size))
++		pgprot = pgprot_device(pgprot);
++#endif
++
+ 	return generic_ioremap_prot(phys_addr, size, pgprot);
+ }
+ EXPORT_SYMBOL(ioremap_prot);
+diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
+index 8103bc24a54e..8de3dcb1d03a 100644
+--- a/drivers/pci/quirks.c
++++ b/drivers/pci/quirks.c
+@@ -6270,6 +6270,15 @@ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_XILINX, 0x5020, of_pci_make_dev_node);
+ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_XILINX, 0x5021, of_pci_make_dev_node);
+ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_REDHAT, 0x0005, of_pci_make_dev_node);
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++static void quirk_altra_erratum_82288(struct pci_dev *dev)
++{
++	pr_info_once("Write combining PCI maps disabled due to hardware erratum\n");
++	static_branch_enable(&have_altra_erratum_82288);
++}
++DECLARE_PCI_FIXUP_EARLY(PCI_VENDOR_ID_AMPERE, 0xe100, quirk_altra_erratum_82288);
++#endif
++
+ /*
+  * Devices known to require a longer delay before first config space access
+  * after reset recovery or resume from D3cold:
+-- 
+2.48.1
+


### PR DESCRIPTION
Changes in arch/arm64/include/asm/pgtable.h at v6.12 keep the old patch from applying.

Resolves AmpereComputing/linux-ampere-altra-erratum-pcie-65#5