### PR TITLE
Fix ttbr0 emulation of dc zva

### DIFF
--- a/v6.13/0001-ampere-arm64-Add-a-fixup-handler-for-alignment-fault.patch
+++ b/v6.13/0001-ampere-arm64-Add-a-fixup-handler-for-alignment-fault.patch
@@ -191,7 +191,7 @@ index 0000000000000..86d6c62aac5b9
 +	addr &= ~(sz - 1);
 +	if (is_ttbr0_addr(addr)) {
 +		for (; sz; sz--) {
-+			if (align_store(addr, 1, 0))
++			if (align_store(addr++, 1, 0))
 +				return 1;
 +		}
 +	} else

--- a/v6.7/0001-ampere-arm64-Add-a-fixup-handler-for-alignment-fault.patch
+++ b/v6.7/0001-ampere-arm64-Add-a-fixup-handler-for-alignment-fault.patch
@@ -191,7 +191,7 @@ index 0000000000000..dd5028398a4c8
 +	addr &= ~(sz - 1);
 +	if (is_ttbr0_addr(addr)) {
 +		for (; sz; sz--) {
-+			if (align_store(addr, 1, 0))
++			if (align_store(addr++, 1, 0))
 +				return 1;
 +		}
 +	} else


### PR DESCRIPTION
The loop to emulate dc zva in the ttbr0 range was mistakenly not updating the address, so not actually clearing all the data in the dc zva access, but only the first byte.