### PR TITLE
Fix load in align_ldst_regoff

### DIFF
--- a/v6.13/0001-ampere-arm64-Add-a-fixup-handler-for-alignment-fault.patch
+++ b/v6.13/0001-ampere-arm64-Add-a-fixup-handler-for-alignment-fault.patch
@@ -63,7 +63,7 @@ new file mode 100644
 index 0000000000000..86d6c62aac5b9
 --- /dev/null
 +++ b/arch/arm64/kernel/alignment.c
-@@ -0,0 +1,1049 @@
+@@ -0,0 +1,1050 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/*
 + * Copyright (C) 2023 Ampere Computing LLC
@@ -519,6 +519,7 @@ index 0000000000000..86d6c62aac5b9
 +			else
 +				data = sign_extend64(data, datasize - 1);
 +		}
++		pt_regs_write_reg(regs, t, data);
 +	}
 +
 +	return 0;

--- a/v6.7/0001-ampere-arm64-Add-a-fixup-handler-for-alignment-fault.patch
+++ b/v6.7/0001-ampere-arm64-Add-a-fixup-handler-for-alignment-fault.patch
@@ -63,7 +63,7 @@ new file mode 100644
 index 0000000000000..dd5028398a4c8
 --- /dev/null
 +++ b/arch/arm64/kernel/alignment.c
-@@ -0,0 +1,1049 @@
+@@ -0,0 +1,1050 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/*
 + * Copyright (C) 2023 Ampere Computing LLC
@@ -519,6 +519,7 @@ index 0000000000000..dd5028398a4c8
 +			else
 +				data = sign_extend64(data, datasize - 1);
 +		}
++		pt_regs_write_reg(regs, t, data);
 +	}
 +
 +	return 0;


### PR DESCRIPTION
Data is not written back to the register and will cause data mismatch.