### PR TITLE
Add patches for kernel v5.4, v

### DIFF
--- a/v5.10/0001-arm64-Work-around-Ampere-Altra-erratum-82288-PCIE_65.patch
+++ b/v5.10/0001-arm64-Work-around-Ampere-Altra-erratum-82288-PCIE_65.patch
@@ -1,0 +1,171 @@
+From 9b2540bca8c7d89459ced5dd1642000dc5abe398 Mon Sep 17 00:00:00 2001
+From: D Scott Phillips <scott@os.amperecomputing.com>
+Date: Fri, 13 Nov 2020 08:25:23 -0800
+Subject: [PATCH 01/10] arm64: Work around Ampere Altra erratum #82288 PCIE_65
+
+Altra's PCIe controller may generate incorrect addresses when receiving
+writes from the CPU with a discontiguous set of byte enables. Attempt to
+work around this by handing out Device-nGnRE maps instead of Normal
+Non-cacheable maps for PCIe memory areas.
+
+Signed-off-by: D Scott Phillips <scott@os.amperecomputing.com>
+---
+ Documentation/arm64/silicon-errata.rst |  3 +++
+ arch/arm64/Kconfig                     |  9 +++++++++
+ arch/arm64/include/asm/pci.h           |  5 +++++
+ arch/arm64/include/asm/pgtable.h       | 26 +++++++++++++++++++++-----
+ arch/arm64/mm/ioremap.c                | 18 ++++++++++++++++++
+ drivers/pci/quirks.c                   |  9 +++++++++
+ 6 files changed, 65 insertions(+), 5 deletions(-)
+
+diff --git a/Documentation/arm64/silicon-errata.rst b/Documentation/arm64/silicon-errata.rst
+index f01eed0ee23a..e8500092f3f7 100644
+--- a/Documentation/arm64/silicon-errata.rst
++++ b/Documentation/arm64/silicon-errata.rst
+@@ -52,6 +52,9 @@ stable kernels.
+ | Allwinner      | A64/R18         | UNKNOWN1        | SUN50I_ERRATUM_UNKNOWN1     |
+ +----------------+-----------------+-----------------+-----------------------------+
+ +----------------+-----------------+-----------------+-----------------------------+
++| Ampere         | Altra           | #82288          | ALTRA_ERRATUM_82288         |
+++----------------+-----------------+-----------------+-----------------------------+
+++----------------+-----------------+-----------------+-----------------------------+
+ | ARM            | Cortex-A53      | #826319         | ARM64_ERRATUM_826319        |
+ +----------------+-----------------+-----------------+-----------------------------+
+ | ARM            | Cortex-A53      | #827319         | ARM64_ERRATUM_827319        |
+diff --git a/arch/arm64/Kconfig b/arch/arm64/Kconfig
+index 7c7906e9dafd..0eb45709710d 100644
+--- a/arch/arm64/Kconfig
++++ b/arch/arm64/Kconfig
+@@ -353,6 +353,15 @@ menu "ARM errata workarounds via the alternatives framework"
+ config ARM64_WORKAROUND_CLEAN_CACHE
+ 	bool
+ 
++config ALTRA_ERRATUM_82288
++	bool "Ampere Altra: 82288: PCIE_65: PCIe Root Port outbound write combining issue"
++	default y
++	help
++	  This option adds an alternative code sequence to work around
++	  Ampere Altra erratum 82288.
++
++	  If unsure, say Y.
++
+ config ARM64_ERRATUM_826319
+ 	bool "Cortex-A53: 826319: System might deadlock if a write cannot complete until read data is accepted"
+ 	default y
+diff --git a/arch/arm64/include/asm/pci.h b/arch/arm64/include/asm/pci.h
+index b33ca260e3c9..fa9d32710e60 100644
+--- a/arch/arm64/include/asm/pci.h
++++ b/arch/arm64/include/asm/pci.h
+@@ -17,7 +17,12 @@
+ #define pcibios_assign_all_busses() \
+ 	(pci_has_flag(PCI_REASSIGN_ALL_BUS))
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++extern bool __read_mostly have_altra_erratum_82288;
++#else
+ #define arch_can_pci_mmap_wc() 1
++#endif
++
+ #define ARCH_GENERIC_PCI_MMAP_RESOURCE	1
+ 
+ extern int isa_dma_bridge_buggy;
+diff --git a/arch/arm64/include/asm/pgtable.h b/arch/arm64/include/asm/pgtable.h
+index 3f74db7b0a31..51853e8230e3 100644
+--- a/arch/arm64/include/asm/pgtable.h
++++ b/arch/arm64/include/asm/pgtable.h
+@@ -220,11 +220,6 @@ static inline pte_t pte_mkyoung(pte_t pte)
+ 	return set_pte_bit(pte, __pgprot(PTE_AF));
+ }
+ 
+-static inline pte_t pte_mkspecial(pte_t pte)
+-{
+-	return set_pte_bit(pte, __pgprot(PTE_SPECIAL));
+-}
+-
+ static inline pte_t pte_mkcont(pte_t pte)
+ {
+ 	pte = set_pte_bit(pte, __pgprot(PTE_CONT));
+@@ -505,6 +500,27 @@ static inline pmd_t pmd_mkdevmap(pmd_t pmd)
+ 	__pgprot_modify(prot, PTE_ATTRINDX_MASK, \
+ 			PTE_ATTRINDX(MT_NORMAL_NC) | PTE_PXN | PTE_UXN)
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++extern bool have_altra_erratum_82288;
++#endif
++
++static inline pte_t pte_mkspecial(pte_t pte)
++{
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++	phys_addr_t phys = __pte_to_phys(pte);
++	pgprot_t prot = __pgprot(pte_val(pte) & ~PTE_ADDR_MASK);
++
++	if (unlikely(have_altra_erratum_82288) &&
++	    (phys < 0x80000000 ||
++	     (phys >= 0x200000000000 && phys < 0x400000000000) ||
++	     (phys >= 0x600000000000 && phys < 0x800000000000))) {
++		pte = __pte(__phys_to_pte_val(phys) | pgprot_val(pgprot_device(prot)));
++	}
++#endif
++
++	return set_pte_bit(pte, __pgprot(PTE_SPECIAL));
++}
++
+ #define __HAVE_PHYS_MEM_ACCESS_PROT
+ struct file;
+ extern pgprot_t phys_mem_access_prot(struct file *file, unsigned long pfn,
+diff --git a/arch/arm64/mm/ioremap.c b/arch/arm64/mm/ioremap.c
+index f173a01a0c0e..e5796efb5060 100644
+--- a/arch/arm64/mm/ioremap.c
++++ b/arch/arm64/mm/ioremap.c
+@@ -18,6 +18,19 @@
+ #include <asm/fixmap.h>
+ #include <asm/tlbflush.h>
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++bool have_altra_erratum_82288 __read_mostly;
++EXPORT_SYMBOL(have_altra_erratum_82288);
++
++static bool is_altra_pci(phys_addr_t phys_addr, size_t size)
++{
++	phys_addr_t end = phys_addr + size;
++	return (phys_addr < 0x80000000 ||
++		(end > 0x200000000000 && phys_addr < 0x400000000000) ||
++		(end > 0x600000000000 && phys_addr < 0x800000000000));
++}
++#endif
++
+ static void __iomem *__ioremap_caller(phys_addr_t phys_addr, size_t size,
+ 				      pgprot_t prot, void *caller)
+ {
+@@ -53,6 +66,11 @@ static void __iomem *__ioremap_caller(phys_addr_t phys_addr, size_t size,
+ 	addr = (unsigned long)area->addr;
+ 	area->phys_addr = phys_addr;
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++	if (unlikely(have_altra_erratum_82288 && is_altra_pci(phys_addr, size)))
++		prot = pgprot_device(prot);
++#endif
++
+ 	err = ioremap_page_range(addr, addr + size, phys_addr, prot);
+ 	if (err) {
+ 		vunmap((void *)addr);
+diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
+index 1be2894ada70..361006465c8a 100644
+--- a/drivers/pci/quirks.c
++++ b/drivers/pci/quirks.c
+@@ -5777,3 +5777,12 @@ static void nvidia_ion_ahci_fixup(struct pci_dev *pdev)
+ 	pdev->dev_flags |= PCI_DEV_FLAGS_HAS_MSI_MASKING;
+ }
+ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_NVIDIA, 0x0ab8, nvidia_ion_ahci_fixup);
++
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++static void quirk_altra_erratum_82288(struct pci_dev *dev)
++{
++	pr_info_once("Write combining PCI maps disabled due to hardware erratum\n");
++	have_altra_erratum_82288 = true;
++}
++DECLARE_PCI_FIXUP_EARLY(PCI_VENDOR_ID_AMPERE, 0xe100, quirk_altra_erratum_82288);
++#endif
+-- 
+2.39.3
+

--- a/v5.10/0002-arm64-Add-a-fixup-handler-for-alignment-faults-in-aa.patch
+++ b/v5.10/0002-arm64-Add-a-fixup-handler-for-alignment-faults-in-aa.patch
@@ -1,0 +1,817 @@
+From f5c303e4bef3bd4e788186de8f318a133894d09e Mon Sep 17 00:00:00 2001
+From: D Scott Phillips <scott@os.amperecomputing.com>
+Date: Thu, 10 Dec 2020 00:07:19 -0800
+Subject: [PATCH 02/10] arm64: Add a fixup handler for alignment faults in
+ aarch64 code
+
+A later patch will hand out Device memory in some cases to code
+which expects a Normal memory type, as an errata workaround.
+Unaligned accesses to Device memory will fault though, so here we
+add a fixup handler to emulate faulting accesses, at a performance
+penalty.
+
+Many of the instructions in the Loads and Stores group are supported,
+but these groups are not handled here:
+
+ * Advanced SIMD load/store multiple structures
+ * Advanced SIMD load/store multiple structures (post-indexed)
+ * Advanced SIMD load/store single structure
+ * Advanced SIMD load/store single structure (post-indexed)
+ * Load/store memory tags
+ * Load/store exclusive
+ * LDAPR/STLR (unscaled immediate)
+ * Load register (literal) [cannot Alignment fault]
+ * Load/store register (unprivileged)
+ * Atomic memory operations
+ * Load/store register (pac)
+
+Instruction implementations are translated from the Exploration tools'
+ASL specifications.
+
+Signed-off-by: D Scott Phillips <scott@os.amperecomputing.com>
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/include/asm/insn.h |   1 +
+ arch/arm64/mm/fault.c         | 744 ++++++++++++++++++++++++++++++++++
+ 2 files changed, 745 insertions(+)
+
+diff --git a/arch/arm64/include/asm/insn.h b/arch/arm64/include/asm/insn.h
+index d45b42295254..cfb5147f31e1 100644
+--- a/arch/arm64/include/asm/insn.h
++++ b/arch/arm64/include/asm/insn.h
+@@ -370,6 +370,7 @@ __AARCH64_INSN_FUNCS(eret_auth,	0xFFFFFBFF, 0xD69F0BFF)
+ __AARCH64_INSN_FUNCS(mrs,	0xFFF00000, 0xD5300000)
+ __AARCH64_INSN_FUNCS(msr_imm,	0xFFF8F01F, 0xD500401F)
+ __AARCH64_INSN_FUNCS(msr_reg,	0xFFF00000, 0xD5100000)
++__AARCH64_INSN_FUNCS(dc_zva,	0xFFFFFFE0, 0xD50B7420)
+ 
+ #undef	__AARCH64_INSN_FUNCS
+ 
+diff --git a/arch/arm64/mm/fault.c b/arch/arm64/mm/fault.c
+index 795d224f184f..ed1605469d62 100644
+--- a/arch/arm64/mm/fault.c
++++ b/arch/arm64/mm/fault.c
+@@ -5,6 +5,7 @@
+  * Copyright (C) 1995  Linus Torvalds
+  * Copyright (C) 1995-2004 Russell King
+  * Copyright (C) 2012 ARM Ltd.
++ * Copyright (C) 2020 Ampere Computing LLC
+  */
+ 
+ #include <linux/acpi.h>
+@@ -607,9 +608,752 @@ static int __kprobes do_translation_fault(unsigned long addr,
+ 	return 0;
+ }
+ 
++static int copy_from_user_io(void *to, const void __user *from, unsigned long n)
++{
++	const u8 __user *src = from;
++	u8 *dest = to;
++
++	for (; n; n--)
++		if (get_user(*dest++, src++))
++			break;
++	return n;
++}
++
++static int copy_to_user_io(void __user *to, const void *from, unsigned long n)
++{
++	const u8 *src = from;
++	u8 __user *dest = to;
++
++	for (; n; n--)
++		if (put_user(*src++, dest++))
++			break;
++	return n;
++}
++
++static int align_load(unsigned long addr, int sz, u64 *out)
++{
++	union {
++		u8 d8;
++		u16 d16;
++		u32 d32;
++		u64 d64;
++		char c[8];
++	} data;
++
++	if (sz != 1 && sz != 2 && sz != 4 && sz != 8)
++		return 1;
++	if (is_ttbr0_addr(addr)) {
++		if (copy_from_user_io(data.c, (const void __user *)addr, sz))
++			return 1;
++	} else
++		memcpy_fromio(data.c, (const void __iomem *)addr, sz);
++	switch (sz) {
++	case 1:
++		*out = data.d8;
++		break;
++	case 2:
++		*out = data.d16;
++		break;
++	case 4:
++		*out = data.d32;
++		break;
++	case 8:
++		*out = data.d64;
++		break;
++	default:
++		return 1;
++	}
++	return 0;
++}
++
++static int align_store(unsigned long addr, int sz, u64 val)
++{
++	union {
++		u8 d8;
++		u16 d16;
++		u32 d32;
++		u64 d64;
++		char c[8];
++	} data;
++
++	switch (sz) {
++	case 1:
++		data.d8 = val;
++		break;
++	case 2:
++		data.d16 = val;
++		break;
++	case 4:
++		data.d32 = val;
++		break;
++	case 8:
++		data.d64 = val;
++		break;
++	default:
++		return 1;
++	}
++	if (is_ttbr0_addr(addr)) {
++		if (copy_to_user_io((void __user *)addr, data.c, sz))
++			return 1;
++	} else
++		memcpy_toio((void __iomem *)addr, data.c, sz);
++	return 0;
++}
++
++static int align_dc_zva(unsigned long addr, struct pt_regs *regs)
++{
++	int bs = read_cpuid(DCZID_EL0) & 0xf;
++	int sz = 1 << (bs + 2);
++
++	addr &= ~(sz - 1);
++	if (is_ttbr0_addr(addr)) {
++		for (; sz; sz--) {
++			if (align_store(addr, 1, 0))
++				return 1;
++		}
++	} else
++		memset_io((void *)addr, 0, sz);
++	return 0;
++}
++
++static u64 get_vn_dt(int n, int t) {
++	u64 res;
++
++	switch (n) {
++#define V(n)						\
++	case n:						\
++		asm("cbnz %w1, 1f\n\t"			\
++		    "mov %0, v"#n".d[0]\n\t"		\
++		    "b 2f\n\t"				\
++		    "1: mov %0, v"#n".d[1]\n\t"		\
++		    "2:" : "=r" (res) : "r" (t));	\
++		break
++	V( 0); V( 1); V( 2); V( 3); V( 4); V( 5); V( 6); V( 7);
++	V( 8); V( 9); V(10); V(11); V(12); V(13); V(14); V(15);
++	V(16); V(17); V(18); V(19); V(20); V(21); V(22); V(23);
++	V(24); V(25); V(26); V(27); V(28); V(29); V(30); V(31);
++#undef V
++	default:
++		res = 0;
++		break;
++	}
++	return res;
++}
++
++static void set_vn_dt(int n, int t, u64 val) {
++	switch (n) {
++#define V(n)						\
++	case n:						\
++		asm("cbnz %w1, 1f\n\t"			\
++		    "mov v"#n".d[0], %0\n\t"		\
++		    "b 2f\n\t"				\
++		    "1: mov v"#n".d[1], %0\n\t"		\
++		    "2:" :: "r" (val), "r" (t));	\
++		break
++	V( 0); V( 1); V( 2); V( 3); V( 4); V( 5); V( 6); V( 7);
++	V( 8); V( 9); V(10); V(11); V(12); V(13); V(14); V(15);
++	V(16); V(17); V(18); V(19); V(20); V(21); V(22); V(23);
++	V(24); V(25); V(26); V(27); V(28); V(29); V(30); V(31);
++#undef Q
++	default:
++		break;
++	}
++}
++
++static int align_ldst_pair(u32 insn, struct pt_regs *regs)
++{
++	const u32 OPC = GENMASK(31, 30);
++	const u32 L_MASK = BIT(22);
++
++	int opc = FIELD_GET(OPC, insn);
++	int L = FIELD_GET(L_MASK, insn);
++
++	bool wback = !!(insn & BIT(23));
++	bool postindex = !(insn & BIT(24));
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int t2 = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT2, insn);
++	bool is_store = !L;
++	bool is_signed = !!(opc & 1);
++	int scale = 2 + (opc >> 1);
++	int datasize = 8 << scale;
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_7, insn);
++	s64 offset = sign_extend64(uoffset, 6) << scale;
++	u64 address;
++	u64 data1, data2;
++	u64 dbytes;
++
++	if ((is_store && (opc & 1)) || opc == 3)
++		return 1;
++
++	if (wback && (t == n || t2 == n) && n != 31)
++		return 1;
++
++	if (!is_store && t == t2)
++		return 1;
++
++	dbytes = datasize / 8;
++
++	address = regs_get_register(regs, n << 3);
++
++	if (!postindex)
++		address += offset;
++
++	if (is_store) {
++		data1 = pt_regs_read_reg(regs, t);
++		data2 = pt_regs_read_reg(regs, t2);
++		if (align_store(address, dbytes, data1) ||
++		    align_store(address + dbytes, dbytes, data2))
++			return 1;
++	} else {
++		if (align_load(address, dbytes, &data1) ||
++		    align_load(address + dbytes, dbytes, &data2))
++			return 1;
++		if (is_signed) {
++			data1 = sign_extend64(data1, datasize - 1);
++			data2 = sign_extend64(data2, datasize - 1);
++		}
++		pt_regs_write_reg(regs, t, data1);
++		pt_regs_write_reg(regs, t2, data2);
++	}
++
++	if (wback) {
++		if (postindex)
++			address += offset;
++		if (n == 31)
++			regs->sp = address;
++		else
++			pt_regs_write_reg(regs, n, address);
++	}
++
++	return 0;
++}
++
++static int align_ldst_pair_simdfp(u32 insn, struct pt_regs *regs)
++{
++	const u32 OPC = GENMASK(31, 30);
++	const u32 L_MASK = BIT(22);
++
++	int opc = FIELD_GET(OPC, insn);
++	int L = FIELD_GET(L_MASK, insn);
++
++	bool wback = !!(insn & BIT(23));
++	bool postindex = !(insn & BIT(24));
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int t2 = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT2, insn);
++	bool is_store = !L;
++	int scale = 2 + opc;
++	int datasize = 8 << scale;
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_7, insn);
++	s64 offset = sign_extend64(uoffset, 6) << scale;
++	u64 address;
++	u64 data1_d0, data1_d1, data2_d0, data2_d1;
++	u64 dbytes;
++
++	if (opc == 0x3)
++		return 1;
++
++	if (!is_store && t == t2)
++		return 1;
++
++	dbytes = datasize / 8;
++
++	address = regs_get_register(regs, n << 3);
++
++	if (!postindex)
++		address += offset;
++
++	if (is_store) {
++		data1_d0 = get_vn_dt(t, 0);
++		data2_d0 = get_vn_dt(t2, 0);
++		if (datasize == 128) {
++			data1_d1 = get_vn_dt(t, 1);
++			data2_d1 = get_vn_dt(t2, 1);
++			if (align_store(address, 8, data1_d0) ||
++			    align_store(address + 8, 8, data1_d1) ||
++			    align_store(address + 16, 8, data2_d0) ||
++			    align_store(address + 24, 8, data2_d1))
++				return 1;
++		} else {
++			if (align_store(address, dbytes, data1_d0) ||
++			    align_store(address + dbytes, dbytes, data2_d0))
++				return 1;
++		}
++	} else {
++		if (datasize == 128) {
++			if (align_load(address, 8, &data1_d0) ||
++			    align_load(address + 8, 8, &data1_d1) ||
++			    align_load(address + 16, 8, &data2_d0) ||
++			    align_load(address + 24, 8, &data2_d1))
++				return 1;
++		} else {
++			if (align_load(address, dbytes, &data1_d0) ||
++			    align_load(address + dbytes, dbytes, &data2_d0))
++				return 1;
++			data1_d1 = data2_d1 = 0;
++		}
++		set_vn_dt(t, 0, data1_d0);
++		set_vn_dt(t, 1, data1_d1);
++		set_vn_dt(t2, 0, data2_d0);
++		set_vn_dt(t2, 1, data2_d1);
++	}
++
++	if (wback) {
++		if (postindex)
++			address += offset;
++		if (n == 31)
++			regs->sp = address;
++		else
++			pt_regs_write_reg(regs, n, address);
++	}
++
++	return 0;
++}
++
++static int align_ldst_regoff(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++	const u32 OPTION = GENMASK(15, 13);
++	const u32 S = BIT(12);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	u32 option = FIELD_GET(OPTION, insn);
++	u32 s = FIELD_GET(S, insn);
++	int scale = size;
++	int extend_len = (option & 0x1) ? 64 : 32;
++	bool extend_unsigned = !(option & 0x4);
++	int shift = s ? scale : 0;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int m = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RM, insn);
++	bool is_store;
++	bool is_signed;
++	int regsize;
++	int datasize;
++	u64 offset;
++	u64 address;
++	u64 data;
++
++	if ((opc & 0x2) == 0) {
++		/* store or zero-extending load */
++		is_store = !(opc & 0x1);
++		regsize = size == 0x3 ? 64 : 32;
++		is_signed = false;
++	} else {
++		if (size == 0x3) {
++			if ((opc & 0x1) == 0) {
++				/* prefetch */
++				return 0;
++			} else {
++				/* undefined */
++				return 1;
++			}
++		} else {
++			/* sign-extending load */
++			is_store = false;
++			if (size == 0x2 && (opc & 0x1) == 0x1) {
++				/* undefined */
++				return 1;
++			}
++			regsize = (opc & 0x1) == 0x1 ? 32 : 64;
++			is_signed = true;
++		}
++	}
++
++	datasize = 8 << scale;
++
++	if (n == t && n != 31)
++		return 1;
++
++	offset = pt_regs_read_reg(regs, m);
++	if (extend_len == 32) {
++		offset &= (u32)~0;
++		if (!extend_unsigned)
++			sign_extend64(offset, 31);
++	}
++	offset <<= shift;
++
++	address = regs_get_register(regs, n << 3) + offset;
++
++	if (is_store) {
++		data = pt_regs_read_reg(regs, t);
++		if (align_store(address, datasize / 8, data))
++			return 1;
++	} else {
++		if (align_load(address, datasize / 8, &data))
++			return 1;
++		if (is_signed) {
++			if (regsize == 32)
++				data = sign_extend32(data, datasize - 1);
++			else
++				data = sign_extend64(data, datasize - 1);
++		}
++	}
++
++	return 0;
++}
++
++static int align_ldst_regoff_simdfp(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++	const u32 OPTION = GENMASK(15, 13);
++	const u32 S = BIT(12);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	u32 option = FIELD_GET(OPTION, insn);
++	u32 s = FIELD_GET(S, insn);
++	int scale = (opc & 0x2) << 1 | size;
++	int extend_len = (option & 0x1) ? 64 : 32;
++	bool extend_unsigned = !(option & 0x4);
++	int shift = s ? scale : 0;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int m = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RM, insn);
++	bool is_store = !(opc & BIT(0));
++	int datasize;
++	u64 offset;
++	u64 address;
++	u64 data_d0, data_d1;
++
++	if ((opc & 0x2) == 0)
++		return 1;
++
++	datasize = 8 << scale;
++
++	if (n == t && n != 31)
++		return 1;
++
++	offset = pt_regs_read_reg(regs, m);
++	if (extend_len == 32) {
++		offset &= (u32)~0;
++		if (!extend_unsigned)
++			sign_extend64(offset, 31);
++	}
++	offset <<= shift;
++
++	address = regs_get_register(regs, n << 3) + offset;
++
++	if (is_store) {
++		data_d0 = get_vn_dt(t, 0);
++		if (datasize == 128) {
++			data_d1 = get_vn_dt(t, 1);
++			if (align_store(address, 8, data_d0) ||
++			    align_store(address + 8, 8, data_d1))
++				return 1;
++		} else {
++			if (align_store(address, datasize / 8, data_d0))
++				return 1;
++		}
++	} else {
++		if (datasize == 128) {
++			if (align_load(address, 8, &data_d0) ||
++			    align_load(address + 8, 8, &data_d1))
++				return 1;
++		} else {
++			if (align_load(address, datasize / 8, &data_d0))
++				return 1;
++			data_d1 = 0;
++		}
++		set_vn_dt(t, 0, data_d0);
++		set_vn_dt(t, 1, data_d1);
++	}
++
++	return 0;
++}
++
++static int align_ldst_imm(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	bool wback = !(insn & BIT(24)) && !!(insn & BIT(10));
++	bool postindex = wback && !(insn & BIT(11));
++	int scale = size;
++	u64 offset;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	bool is_store;
++	bool is_signed;
++	int regsize;
++	int datasize;
++	u64 address;
++	u64 data;
++
++	if (!(insn & BIT(24))) {
++		u64 uoffset =
++			aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++		offset = sign_extend64(uoffset, 8);
++	} else {
++		offset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_12, insn);
++		offset <<= scale;
++	}
++
++	if ((opc & 0x2) == 0) {
++		/* store or zero-extending load */
++		is_store = !(opc & 0x1);
++		regsize = size == 0x3 ? 64 : 32;
++		is_signed = false;
++	} else {
++		if (size == 0x3) {
++			if (FIELD_GET(GENMASK(11, 10), insn) == 0 && (opc & 0x1) == 0) {
++				/* prefetch */
++				return 0;
++			} else {
++				/* undefined */
++				return 1;
++			}
++		} else {
++			/* sign-extending load */
++			is_store = false;
++			if (size == 0x2 && (opc & 0x1) == 0x1) {
++				/* undefined */
++				return 1;
++			}
++			regsize = (opc & 0x1) == 0x1 ? 32 : 64;
++			is_signed = true;
++		}
++	}
++
++	datasize = 8 << scale;
++
++	if (n == t && n != 31)
++		return 1;
++
++	address = regs_get_register(regs, n << 3);
++
++	if (!postindex)
++		address += offset;
++
++	if (is_store) {
++		data = pt_regs_read_reg(regs, t);
++		if (align_store(address, datasize / 8, data))
++			return 1;
++	} else {
++		if (align_load(address, datasize / 8, &data))
++			return 1;
++		if (is_signed) {
++			if (regsize == 32)
++				data = sign_extend32(data, datasize - 1);
++			else
++				data = sign_extend64(data, datasize - 1);
++		}
++		pt_regs_write_reg(regs, t, data);
++	}
++
++	if (wback) {
++		if (postindex)
++			address += offset;
++		if (n == 31)
++			regs->sp = address;
++		else
++			pt_regs_write_reg(regs, n, address);
++	}
++
++	return 0;
++}
++
++static int align_ldst_imm_simdfp(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	bool wback = !(insn & BIT(24)) && !!(insn & BIT(10));
++	bool postindex = wback && !(insn & BIT(11));
++	int scale = (opc & 0x2) << 1 | size;
++	u64 offset;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	bool is_store = !(opc & BIT(0)) ;
++	int datasize;
++	u64 address;
++	u64 data_d0, data_d1;
++
++	if (scale > 4)
++		return 1;
++
++	if (!(insn & BIT(24))) {
++		u64 uoffset =
++			aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++		offset = sign_extend64(uoffset, 8);
++	} else {
++		offset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_12, insn);
++		offset <<= scale;
++	}
++
++	datasize = 8 << scale;
++
++	address = regs_get_register(regs, n << 3);
++
++	if (!postindex)
++		address += offset;
++
++	if (is_store) {
++		data_d0 = get_vn_dt(t, 0);
++		if (datasize == 128) {
++			data_d1 = get_vn_dt(t, 1);
++			if (align_store(address, 8, data_d0) ||
++			    align_store(address + 8, 8, data_d1))
++				return 1;
++		} else {
++			if (align_store(address, datasize / 8, data_d0))
++				return 1;
++		}
++	} else {
++		if (datasize == 128) {
++			if (align_load(address, 8, &data_d0) ||
++			    align_load(address + 8, 8, &data_d1))
++				return 1;
++		} else {
++			if (align_load(address, datasize / 8, &data_d0))
++				return 1;
++			data_d1 = 0;
++		}
++		set_vn_dt(t, 0, data_d0);
++		set_vn_dt(t, 1, data_d1);
++	}
++
++	if (wback) {
++		if (postindex)
++			address += offset;
++		if (n == 31)
++			regs->sp = address;
++		else
++			pt_regs_write_reg(regs, n, address);
++	}
++
++	return 0;
++}
++
++static int align_ldst(u32 insn, struct pt_regs *regs)
++{
++	const u32 op0 = FIELD_GET(GENMASK(31, 28), insn);
++	const u32 op1 = FIELD_GET(BIT(26), insn);
++	const u32 op2 = FIELD_GET(GENMASK(24, 23), insn);
++	const u32 op3 = FIELD_GET(GENMASK(21, 16), insn);
++	const u32 op4 = FIELD_GET(GENMASK(11, 10), insn);
++
++	if ((op0 & 0x3) == 0x2) {
++		/*
++		 * |------+-----+-----+-----+-----+-----------------------------------------|
++		 * | op0  | op1 | op2 | op3 | op4 | Decode group                            |
++		 * |------+-----+-----+-----+-----+-----------------------------------------|
++		 * | xx10 | -   |  00 | -   | -   | Load/store no-allocate pair (offset)    |
++		 * | xx10 | -   |  01 | -   | -   | Load/store register pair (post-indexed) |
++		 * | xx10 | -   |  10 | -   | -   | Load/store register pair (offset)       |
++		 * | xx10 | -   |  11 | -   | -   | Load/store register pair (pre-indexed)  |
++		 * |------+-----+-----+-----+-----+-----------------------------------------|
++		 */
++
++		if (op1 == 0) { /* V == 0 */
++			/* general */
++			return align_ldst_pair(insn, regs);
++		} else {
++			/* simdfp */
++			return align_ldst_pair_simdfp(insn, regs);
++		}
++	} else if ((op0 & 0x3) == 0x3 &&
++		   (((op2 & 0x2) == 0 && (op3 & 0x20) == 0 && op4 != 0x2) ||
++		    ((op2 & 0x2) == 0x2))) {
++		/*
++		 * |------+-----+-----+--------+-----+----------------------------------------------|
++		 * | op0  | op1 | op2 |    op3 | op4 | Decode group                                 |
++		 * |------+-----+-----+--------+-----+----------------------------------------------|
++		 * | xx11 | -   |  0x | 0xxxxx |  00 | Load/store register (unscaled immediate)     |
++		 * | xx11 | -   |  0x | 0xxxxx |  01 | Load/store register (immediate post-indexed) |
++		 * | xx11 | -   |  0x | 0xxxxx |  11 | Load/store register (immediate pre-indexed)  |
++		 * | xx11 | -   |  1x |      - |   - | Load/store register (unsigned immediate)     |
++		 * |------+-----+-----+--------+-----+----------------------------------------------|
++		 */
++
++		if (op1 == 0) {  /* V == 0 */
++			/* general */
++			return align_ldst_imm(insn, regs);
++		} else {
++			/* simdfp */
++			return align_ldst_imm_simdfp(insn, regs);
++		}
++	} else if ((op0 & 0x3) == 0x3 && (op2 & 0x2) == 0 &&
++		   (op3 & 0x20) == 0x20 && op4 == 0x2) {
++		/*
++		 * |------+-----+-----+--------+-----+---------------------------------------|
++		 * | op0  | op1 | op2 |    op3 | op4 |                                       |
++		 * |------+-----+-----+--------+-----+---------------------------------------|
++		 * | xx11 | -   |  0x | 1xxxxx |  10 | Load/store register (register offset) |
++		 * |------+-----+-----+--------+-----+---------------------------------------|
++		 */
++		if (op1 == 0) { /* V == 0 */
++			/* general */
++			return align_ldst_regoff(insn, regs);
++		} else {
++			/* simdfp */
++			return align_ldst_regoff_simdfp(insn, regs);
++		}
++	} else
++		return 1;
++}
++
++static int fixup_alignment(unsigned long addr, unsigned int esr,
++			   struct pt_regs *regs)
++{
++	u32 insn;
++	int res;
++
++	if (user_mode(regs)) {
++		__le32 insn_le;
++
++		if (!is_ttbr0_addr(addr))
++			return 1;
++
++		if (get_user(insn_le,
++			     (__le32 __user *)instruction_pointer(regs)))
++			return 1;
++		insn = le32_to_cpu(insn_le);
++	} else {
++		if (aarch64_insn_read((void *)instruction_pointer(regs), &insn))
++			return 1;
++	}
++
++	switch (aarch64_get_insn_class(insn)) {
++	case AARCH64_INSN_CLS_BR_SYS:
++		if (aarch64_insn_is_dc_zva(insn))
++			res = align_dc_zva(addr, regs);
++		else
++			res = 1;
++		break;
++	case AARCH64_INSN_CLS_LDST:
++		res = align_ldst(insn, regs);
++		break;
++	default:
++		res = 1;
++	}
++	if (!res) {
++		instruction_pointer_set(regs, instruction_pointer(regs) + 4);
++	}
++	return res;
++}
++
+ static int do_alignment_fault(unsigned long addr, unsigned int esr,
+ 			      struct pt_regs *regs)
+ {
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++	if (!fixup_alignment(addr, esr, regs))
++		return 0;
++#endif
+ 	do_bad_area(addr, esr, regs);
+ 	return 0;
+ }
+-- 
+2.39.3
+

--- a/v5.10/0003-arm64-Add-alignment-faults-handler-for-Advanced-SIMD.patch
+++ b/v5.10/0003-arm64-Add-alignment-faults-handler-for-Advanced-SIMD.patch
@@ -1,0 +1,207 @@
+From aeed024e19a8e899efe85e805387e263885a33a9 Mon Sep 17 00:00:00 2001
+From: D Scott Phillips <scott@os.amperecomputing.com>
+Date: Thu, 3 Mar 2022 15:43:08 +0800
+Subject: [PATCH 03/10] arm64: Add alignment faults handler for Advanced SIMD
+ load/store single
+
+Signed-off-by: D Scott Phillips <scott@os.amperecomputing.com>
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/mm/fault.c | 160 +++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 159 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/mm/fault.c b/arch/arm64/mm/fault.c
+index ed1605469d62..8313439f3c16 100644
+--- a/arch/arm64/mm/fault.c
++++ b/arch/arm64/mm/fault.c
+@@ -712,7 +712,7 @@ static int align_dc_zva(unsigned long addr, struct pt_regs *regs)
+ 				return 1;
+ 		}
+ 	} else
+-		memset_io((void *)addr, 0, sz);
++		memset_io((void __iomem *)addr, 0, sz);
+ 	return 0;
+ }
+ 
+@@ -760,6 +760,44 @@ static void set_vn_dt(int n, int t, u64 val) {
+ 	}
+ }
+ 
++static u64 replicate64(u64 val, int bits)
++{
++	switch (bits) {
++	case 8:
++		val = (val << 8) | (val & 0xff);
++		fallthrough;
++	case 16:
++		val = (val << 16) | (val & 0xffff);
++		fallthrough;
++	case 32:
++		val = (val << 32) | (val & 0xffffffff);
++		break;
++	default:
++		break;
++	}
++	return val;
++}
++
++static u64 elem_get(u64 hi, u64 lo, int index, int esize)
++{
++	int shift = index * esize;
++	u64 mask = GENMASK(esize - 1, 0);
++	if (shift < 64)
++		return (lo >> shift) & mask;
++	else
++		return (hi >> (shift - 64)) & mask;
++}
++
++static void elem_set(u64 *hi, u64 *lo, int index, int esize, u64 val)
++{
++	int shift = index * esize;
++	u64 mask = GENMASK(esize - 1, 0);
++	if (shift < 64)
++		*lo = (*lo & ~(mask << shift)) | ((val & mask) << shift);
++	else
++		*hi = (*hi & ~(mask << (shift - 64))) | ((val & mask) << (shift - 64));
++}
++
+ static int align_ldst_pair(u32 insn, struct pt_regs *regs)
+ {
+ 	const u32 OPC = GENMASK(31, 30);
+@@ -1239,6 +1277,114 @@ static int align_ldst_imm_simdfp(u32 insn, struct pt_regs *regs)
+ 	return 0;
+ }
+ 
++static int align_ldst_vector_single(u32 insn, struct pt_regs *regs)
++{
++	const u32 Q_MASK = BIT(30);
++	const u32 L_MASK = BIT(22);
++	const u32 R_MASK = BIT(21);
++	const u32 OPCODE = GENMASK(15, 13);
++	const u32 S_MASK = BIT(12);
++	const u32 SIZE = GENMASK(11, 10);
++	u32 Q = FIELD_GET(Q_MASK, insn);
++	u32 L = FIELD_GET(L_MASK, insn);
++	u32 R = FIELD_GET(R_MASK, insn);
++	u32 opcode = FIELD_GET(OPCODE, insn);
++	u32 S = FIELD_GET(S_MASK, insn);
++	u32 size = FIELD_GET(SIZE, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int m = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RM, insn);
++	bool wback = !!(insn & BIT(23));
++	int init_scale = opcode >> 1;
++	int scale = init_scale;
++	int selem = (((opcode & 1) << 1) | R) + 1;
++	bool replicate = false;
++	int index;
++	int datasize;
++	int esize;
++	u64 address;
++	u64 offs;
++	u64 rval_d0, rval_d1;
++	u64 element;
++	int ebytes;
++	int s;
++	u64 data;
++	switch (scale) {
++	case 3:
++		if (!L || S)
++			return 1;
++		scale = size;
++		replicate = true;
++		break;
++	case 0:
++		index = (Q << 3) | (S << 2) | size;
++		break;
++	case 1:
++		if (size & 1)
++			return 1;
++		index = (Q << 2) | (S << 1) | (size >> 1);
++		break;
++	case 2:
++		if (size & 2)
++			return 1;
++		if (!(size & 1))
++			index = (Q << 1) | S;
++		else {
++			if (S)
++				return 1;
++			index = Q;
++			scale = 3;
++		}
++		break;
++	}
++	datasize = Q ? 128 : 64;
++	esize = 8 << scale;
++	ebytes = esize / 8;
++	address = regs_get_register(regs, n << 3);
++	offs = 0;
++	if (replicate) {
++		for (s = 0; s < selem; s++) {
++			if (align_load(address + offs, ebytes, &element))
++				return 1;
++			data = replicate64(element, esize);
++			set_vn_dt(t, 0, data);
++			if (datasize == 128)
++				set_vn_dt(t, 1, data);
++			else
++				set_vn_dt(t, 1, 0);
++			offs += ebytes;
++			t = (t + 1) & 31;
++		}
++	} else {
++		for (s = 0; s < selem; s++) {
++			rval_d0 = get_vn_dt(t, 0);
++			rval_d1 = get_vn_dt(t, 1);
++			if (L) {
++				if (align_load(address + offs, ebytes, &data))
++					return 1;
++				elem_set(&rval_d1, &rval_d0, index, esize, data);
++				set_vn_dt(t, 0, rval_d0);
++				set_vn_dt(t, 1, rval_d1);
++			} else {
++				data = elem_get(rval_d1, rval_d0, index, esize);
++				if (align_store(address + offs, ebytes, data))
++					return 1;
++			}
++			offs += ebytes;
++			t = (t + 1) & 31;
++		}
++	}
++	if (wback) {
++		if (m != 31)
++			offs = regs_get_register(regs, m << 3);
++		if (n == 31)
++			regs->sp = address + offs;
++		else
++			pt_regs_write_reg(regs, n, address + offs);
++	}
++	return 0;
++}
++
+ static int align_ldst(u32 insn, struct pt_regs *regs)
+ {
+ 	const u32 op0 = FIELD_GET(GENMASK(31, 28), insn);
+@@ -1303,6 +1449,18 @@ static int align_ldst(u32 insn, struct pt_regs *regs)
+ 			/* simdfp */
+ 			return align_ldst_regoff_simdfp(insn, regs);
+ 		}
++	} else if ((op0 & 0xb) == 0 && op1 == 1 &&
++		   ((op2 == 2 && ((op3 & 0x1f) == 0)) || op2 == 3)) {
++		/*
++		 * |------+-----+-----+--------+-----+-------------------------------------------|
++		 * | op0  | op1 | op2 |    op3 | op4 |                                           |
++		 * |------+-----+-----+--------+-----+-------------------------------------------|
++		 * | 0x00 |   1 |  10 | x00000 |   - | Advanced SIMD load/store single structure |
++		 * | 0x00 |   1 |  11 |      - |   - | Advanced SIMD load/store single structure |
++		 * |      |     |     |        |     |   (post-indexed)                          |
++		 * |------+-----+-----+--------+-----+-------------------------------------------|
++		 */
++		return align_ldst_vector_single(insn, regs);
+ 	} else
+ 		return 1;
+ }
+-- 
+2.39.3
+

--- a/v5.10/0004-arm64-remove-the-hardcode-about-PCI-address-checking.patch
+++ b/v5.10/0004-arm64-remove-the-hardcode-about-PCI-address-checking.patch
@@ -1,0 +1,139 @@
+From a8d2bce4f23dce4e41477eb9f7cb587078c03a67 Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Fri, 8 Apr 2022 20:43:33 +0000
+Subject: [PATCH 04/10] arm64: remove the hardcode about PCI address checking
+
+Copy name in find_next_iomem_res() for checking the PCI
+address.
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/include/asm/pgtable.h |  7 ++----
+ arch/arm64/mm/ioremap.c          |  4 ++-
+ include/linux/pci.h              |  3 +++
+ kernel/resource.c                | 43 ++++++++++++++++++++++++++++++++
+ 4 files changed, 51 insertions(+), 6 deletions(-)
+
+diff --git a/arch/arm64/include/asm/pgtable.h b/arch/arm64/include/asm/pgtable.h
+index 51853e8230e3..f20e762128d1 100644
+--- a/arch/arm64/include/asm/pgtable.h
++++ b/arch/arm64/include/asm/pgtable.h
+@@ -501,7 +501,7 @@ static inline pmd_t pmd_mkdevmap(pmd_t pmd)
+ 			PTE_ATTRINDX(MT_NORMAL_NC) | PTE_PXN | PTE_UXN)
+ 
+ #ifdef CONFIG_ALTRA_ERRATUM_82288
+-extern bool have_altra_erratum_82288;
++extern bool range_is_pci(phys_addr_t, size_t);
+ #endif
+ 
+ static inline pte_t pte_mkspecial(pte_t pte)
+@@ -510,10 +510,7 @@ static inline pte_t pte_mkspecial(pte_t pte)
+ 	phys_addr_t phys = __pte_to_phys(pte);
+ 	pgprot_t prot = __pgprot(pte_val(pte) & ~PTE_ADDR_MASK);
+ 
+-	if (unlikely(have_altra_erratum_82288) &&
+-	    (phys < 0x80000000 ||
+-	     (phys >= 0x200000000000 && phys < 0x400000000000) ||
+-	     (phys >= 0x600000000000 && phys < 0x800000000000))) {
++	if (range_is_pci(phys, PAGE_SIZE)) {
+ 		pte = __pte(__phys_to_pte_val(phys) | pgprot_val(pgprot_device(prot)));
+ 	}
+ #endif
+diff --git a/arch/arm64/mm/ioremap.c b/arch/arm64/mm/ioremap.c
+index e5796efb5060..fe489ab1ea01 100644
+--- a/arch/arm64/mm/ioremap.c
++++ b/arch/arm64/mm/ioremap.c
+@@ -14,6 +14,7 @@
+ #include <linux/vmalloc.h>
+ #include <linux/io.h>
+ #include <linux/memblock.h>
++#include <linux/pci.h>
+ 
+ #include <asm/fixmap.h>
+ #include <asm/tlbflush.h>
+@@ -67,7 +68,8 @@ static void __iomem *__ioremap_caller(phys_addr_t phys_addr, size_t size,
+ 	area->phys_addr = phys_addr;
+ 
+ #ifdef CONFIG_ALTRA_ERRATUM_82288
+-	if (unlikely(have_altra_erratum_82288 && is_altra_pci(phys_addr, size)))
++	if ((pgprot_val(prot) != pgprot_val(pgprot_device(prot))) &&
++			range_is_pci(phys_addr, size))
+ 		prot = pgprot_device(prot);
+ #endif
+ 
+diff --git a/include/linux/pci.h b/include/linux/pci.h
+index bc5a1150f072..cf58611730b3 100644
+--- a/include/linux/pci.h
++++ b/include/linux/pci.h
+@@ -2430,4 +2430,7 @@ void pci_uevent_ers(struct pci_dev *pdev, enum  pci_ers_result err_type);
+ 	WARN_ONCE(condition, "%s %s: " fmt, \
+ 		  dev_driver_string(&(pdev)->dev), pci_name(pdev), ##arg)
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++extern bool range_is_pci(phys_addr_t phys_addr, size_t size);
++#endif
+ #endif /* LINUX_PCI_H */
+diff --git a/kernel/resource.c b/kernel/resource.c
+index 817545ff80b9..e44f9eeb9326 100644
+--- a/kernel/resource.c
++++ b/kernel/resource.c
+@@ -388,6 +388,7 @@ static int find_next_iomem_res(resource_size_t start, resource_size_t end,
+ 			.flags = p->flags,
+ 			.desc = p->desc,
+ 			.parent = p->parent,
++			.name = p->name,
+ 		};
+ 	}
+ 
+@@ -516,6 +517,48 @@ int __weak page_is_ram(unsigned long pfn)
+ }
+ EXPORT_SYMBOL_GPL(page_is_ram);
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++/* Return 0 on success, else return 1 */
++static int pci_addr_check(struct resource *r, void *p)
++{
++	if (!r->name)
++		return 1;
++
++	if (strlen(r->name) <= 2)
++		return 1;
++
++	if (memcmp(r->name, "PCI", 3))
++		return 1;
++
++	/* Success */
++	return 0;
++}
++
++bool range_is_pci(phys_addr_t phys_addr, size_t size)
++{
++	u64 start, end;
++	int ret;
++
++	start = phys_addr;
++	end = phys_addr + size;
++
++	/* Check the 32bit */
++	ret = walk_iomem_res_desc(IORES_DESC_NONE, IORESOURCE_MEM,
++			start, end, NULL, pci_addr_check);
++	if (!ret)
++		return true;
++
++	/* Check the 64bit */
++	ret = walk_iomem_res_desc(IORES_DESC_NONE, IORESOURCE_MEM_64,
++			start, end, NULL, pci_addr_check);
++	if (!ret)
++		return true;
++
++	return false;
++}
++EXPORT_SYMBOL_GPL(range_is_pci);
++#endif
++
+ /**
+  * region_intersects() - determine intersection of region with known resources
+  * @start: region start address
+-- 
+2.39.3
+

--- a/v5.10/0005-arm64-Add-new-code-for-unaligned-pcie-access.patch
+++ b/v5.10/0005-arm64-Add-new-code-for-unaligned-pcie-access.patch
@@ -1,0 +1,313 @@
+From 62b87813b2f23d2d3089ec92a0741bd849d37ca2 Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Tue, 12 Apr 2022 12:09:54 +0000
+Subject: [PATCH 05/10] arm64: Add new code for unaligned pcie access
+
+Add a new function align_ldst_new to handle the rest instructions
+if align_ldst() fails.
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/mm/fault.c               |  18 ++-
+ arch/arm64/mm/pcie_unalign_access.c | 235 ++++++++++++++++++++++++++++
+ 2 files changed, 252 insertions(+), 1 deletion(-)
+ create mode 100644 arch/arm64/mm/pcie_unalign_access.c
+
+diff --git a/arch/arm64/mm/fault.c b/arch/arm64/mm/fault.c
+index 8313439f3c16..75c23604938c 100644
+--- a/arch/arm64/mm/fault.c
++++ b/arch/arm64/mm/fault.c
+@@ -1465,11 +1465,15 @@ static int align_ldst(u32 insn, struct pt_regs *regs)
+ 		return 1;
+ }
+ 
++#include "pcie_unalign_access.c"
++
+ static int fixup_alignment(unsigned long addr, unsigned int esr,
+ 			   struct pt_regs *regs)
+ {
+ 	u32 insn;
+ 	int res;
++	struct pt_regs t = *regs;
++	int type;
+ 
+ 	if (user_mode(regs)) {
+ 		__le32 insn_le;
+@@ -1486,7 +1490,10 @@ static int fixup_alignment(unsigned long addr, unsigned int esr,
+ 			return 1;
+ 	}
+ 
+-	switch (aarch64_get_insn_class(insn)) {
++	pr_debug("start to handle insn:%x\n", insn);
++
++	type = aarch64_get_insn_class(insn);
++	switch (type) {
+ 	case AARCH64_INSN_CLS_BR_SYS:
+ 		if (aarch64_insn_is_dc_zva(insn))
+ 			res = align_dc_zva(addr, regs);
+@@ -1495,12 +1502,21 @@ static int fixup_alignment(unsigned long addr, unsigned int esr,
+ 		break;
+ 	case AARCH64_INSN_CLS_LDST:
+ 		res = align_ldst(insn, regs);
++		if (res) {
++			/* Try it again, copy back if we succeed */
++			res = align_ldst_new(insn, &t);
++			if (!res)
++				*regs = t;
++		}
+ 		break;
+ 	default:
+ 		res = 1;
+ 	}
+ 	if (!res) {
+ 		instruction_pointer_set(regs, instruction_pointer(regs) + 4);
++	} else {
++		pr_err("cannot handle insn:%x, type:%d\n", insn, type);
++		dump_stack();
+ 	}
+ 	return res;
+ }
+diff --git a/arch/arm64/mm/pcie_unalign_access.c b/arch/arm64/mm/pcie_unalign_access.c
+new file mode 100644
+index 000000000000..f7c948985296
+--- /dev/null
++++ b/arch/arm64/mm/pcie_unalign_access.c
+@@ -0,0 +1,235 @@
++struct ldst_filter {
++	u32 mask;
++	u32 arm_code;
++	char *name;
++	int (*handler)(struct ldst_filter *, u32, struct pt_regs*);
++};
++
++static int ldst_default(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	pr_alert("instruction :%x(%s) is not implemented.\n", insn, f->name);
++	return 1;
++}
++
++/*
++ * |------+-----+-----+-----+-----+-----------------------------------------|
++ * | op0  | op1 | op2 | op3 | op4 | Decode group                            |
++ * |------+-----+-----+-----+-----+-----------------------------------------|
++ * | xx10 | -   |  00 | -   | -   | Load/store no-allocate pair (offset)    |
++ * | xx10 | -   |  01 | -   | -   | Load/store register pair (post-indexed) |
++ * | xx10 | -   |  10 | -   | -   | Load/store register pair (offset)       |
++ * | xx10 | -   |  11 | -   | -   | Load/store register pair (pre-indexed)  |
++ * |------+-----+-----+-----+-----+-----------------------------------------|
++ */
++static int ldst_type_pair(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	/* The bit 26 is used for SIMD only, please see the spec */
++	if (insn & BIT(26))
++		return align_ldst_pair_simdfp(insn, regs);
++	else
++		return align_ldst_pair(insn, regs);
++}
++
++/*
++ * |------+-----+-----+--------+-----+----------------------------------------------|
++ * | op0  | op1 | op2 |    op3 | op4 | Decode group                                 |
++ * |------+-----+-----+--------+-----+----------------------------------------------|
++ * | xx11 | -   |  0x | 0xxxxx |  00 | Load/store register (unscaled immediate)     |
++ * | xx11 | -   |  0x | 0xxxxx |  01 | Load/store register (immediate post-indexed) |
++ * | xx11 | -   |  0x | 0xxxxx |  11 | Load/store register (immediate pre-indexed)  |
++ * | xx11 | -   |  1x |      - |   - | Load/store register (unsigned immediate)     |
++ * |------+-----+-----+--------+-----+----------------------------------------------|
++ */
++static int ldst_type_imm(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	/* The bit 26 is used for SIMD only, please see the spec */
++	if (insn & BIT(26))
++		return align_ldst_imm_simdfp(insn, regs);
++	else
++		return align_ldst_imm(insn, regs);
++}
++
++/*
++ * |------+-----+-----+--------+-----+---------------------------------------|
++ * | op0  | op1 | op2 |    op3 | op4 |                                       |
++ * |------+-----+-----+--------+-----+---------------------------------------|
++ * | xx11 | -   |  0x | 1xxxxx |  10 | Load/store register (register offset) |
++ * |------+-----+-----+--------+-----+---------------------------------------|
++ */
++static int ldst_type_regoff(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	/* The bit 26 is used for SIMD only, please see the spec */
++	if (insn & BIT(26))
++		return align_ldst_regoff_simdfp(insn, regs);
++	else
++		return align_ldst_regoff(insn, regs);
++}
++
++/*
++ * |------+-----+-----+--------+-----+-------------------------------------------|
++ * | op0  | op1 | op2 |    op3 | op4 |                                           |
++ * |------+-----+-----+--------+-----+-------------------------------------------|
++ * | 0x00 |   1 |  10 | x00000 |   - | Advanced SIMD load/store single structure |
++ * | 0x00 |   1 |  11 |      - |   - | Advanced SIMD load/store single structure |
++ * |      |     |     |        |     |   (post-indexed)                          |
++ * |------+-----+-----+--------+-----+-------------------------------------------|
++ */
++static int ldst_type_vector_single(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	return align_ldst_vector_single(insn, regs);
++}
++
++/* Please see the C4.1.66 */
++static const struct ldst_filter ldst_filters[] = {
++	{
++		.mask		= BIT(31) | GENMASK(29, 28) | BIT(26)
++					| GENMASK(24, 23) | BIT(21),
++		.arm_code	= BIT(21),
++		.name		= "Compare and swap pair",
++		.handler	= ldst_default,
++	}, {
++		.mask		= BIT(31) | GENMASK(29, 28) | BIT(26)
++					| GENMASK(24, 23) | GENMASK(21, 16),
++		.arm_code	= BIT(26),
++		.name		= "Advanced SIMD load/store multiple structures",
++		.handler	= ldst_default,
++	}, {
++		.mask		= BIT(31) | GENMASK(29, 28) | BIT(26)
++					| GENMASK(24, 23) | BIT(21),
++		.arm_code	= BIT(26) | BIT(23),
++		.name		= "Advanced SIMD load/store multiple structures(post-indexed)",
++		.handler	= ldst_default,
++	}, {
++		.mask		= BIT(31) | GENMASK(29, 28) | BIT(26)
++					| GENMASK(24, 23) | GENMASK(20, 16),
++		.arm_code	= BIT(26) | BIT(24),
++		.name		= "Advanced SIMD load/store single structures",
++		.handler	= ldst_type_vector_single,
++	}, {
++		.mask		= BIT(31) | GENMASK(29, 28) | BIT(26) | GENMASK(24, 23),
++		.arm_code	= BIT(26) | BIT(24) | BIT(23),
++		.name		= "Advanced SIMD load/store single structures(post-indexed)",
++		.handler	= ldst_type_vector_single,
++	}, {
++		.mask		= GENMASK(31, 28) | BIT(26) | BIT(24) | BIT(21),
++		.arm_code	= BIT(31) | BIT(30) | BIT(28) | BIT(24) | BIT(21),
++		.name		= "Load/store memory tags",
++		.handler	= ldst_default,
++	}, {
++		.mask		= BIT(31) | GENMASK(29, 28) | BIT(26)
++					| GENMASK(24, 23) | BIT(21),
++		.arm_code	= BIT(31) | BIT(21),
++		.name		= "Load/store exclusive pair",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(26) | GENMASK(24, 23) | BIT(21),
++		.arm_code	= 0,
++		.name		= "Load/store exclusive register",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(26) | GENMASK(24, 23) | BIT(21),
++		.arm_code	= BIT(23),
++		.name		= "Load/store ordered",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(26) | GENMASK(24, 23) | BIT(21),
++		.arm_code	= BIT(23) | BIT(21),
++		.name		= "Compare and swap",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(26) | BIT(24) | BIT(21) |
++					GENMASK(11, 10),
++		.arm_code	= BIT(28) | BIT(24),
++		.name		= "LDAPR/STLR(unscaled immediate)",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24),
++		.arm_code	= BIT(28),
++		.name		= "Load register(literal)",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(28) | BIT(10),
++		.name		= "Memory Copy and Memory Set",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | GENMASK(24, 23),
++		.arm_code	= BIT(29),
++		.name		= "Load/store no-allocate pair(offset)",
++		.handler	= ldst_type_pair,
++	}, {
++		.mask		= GENMASK(29, 28) | GENMASK(24, 23),
++		.arm_code	= BIT(29) | BIT(23),
++		.name		= "Load/store register pair(post-indexed)",
++		.handler	= ldst_type_pair,
++	}, {
++		.mask		= GENMASK(29, 28) | GENMASK(24, 23),
++		.arm_code	= BIT(29) | BIT(24),
++		.name		= "Load/store register pair(offset)",
++		.handler	= ldst_type_pair,
++	}, {
++		.mask		= GENMASK(29, 28) | GENMASK(24, 23),
++		.arm_code	= BIT(29) | BIT(24) | BIT(23),
++		.name		= "Load/store register pair(pre-indexed)",
++		.handler	= ldst_type_pair,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(29) | BIT(28),
++		.name		= "Load/store register (unscaled immediate)",
++		.handler	= ldst_type_imm,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(29) | BIT(28) | BIT(10),
++		.name		= "Load/store register (immediate post-indexed)",
++		.handler	= ldst_type_imm,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(29) | BIT(28) | BIT(11),
++		.name		= "Load/store register (unprivileged)",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(29) | BIT(28) | BIT(11) | BIT(10),
++		.name		= "Load/store register (immediate pre-indexed)",
++		.handler	= ldst_type_imm,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(29) | BIT(28) | BIT(21),
++		.name		= "Atomic memory operation",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(29) | BIT(28) | BIT(21) | BIT(11),
++		.name		= "Load/store register (register offset)",
++		.handler	= ldst_type_regoff,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | BIT(10),
++		.arm_code	= BIT(29) | BIT(28) | BIT(21) | BIT(10),
++		.name		= "Load/store register (pac)",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24),
++		.arm_code	= BIT(29) | BIT(28) | BIT(24),
++		.name		= "Load/store register (unsigned immediate)",
++		.handler	= ldst_type_imm,
++	},
++};
++
++/* Return 0 on success, return 1 on failure. */
++static int align_ldst_new(u32 insn, struct pt_regs *regs)
++{
++	int i;
++	struct ldst_filter *f;
++
++	for (i = 0; i < ARRAY_SIZE(ldst_filters); i++) {
++		f = (struct ldst_filter *)&ldst_filters[i];
++
++		/* Find the correct hander */
++		if ((f->mask & insn) == f->arm_code) {
++			pr_debug("insn:%x, (%s)\n", insn, f->name);
++			return f->handler(f, insn, regs);
++		}
++	}
++
++	return 1;
++}
+-- 
+2.39.3
+

--- a/v5.10/0006-arm64-fix-the-error-for-instruction-b9400000.patch
+++ b/v5.10/0006-arm64-fix-the-error-for-instruction-b9400000.patch
@@ -1,0 +1,128 @@
+From edc438d987996e697eaea32c06cb21f12b49d6bf Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Sun, 17 Apr 2022 14:20:09 +0000
+Subject: [PATCH 06/10] arm64: fix the error for instruction :b9400000
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/mm/pcie_unalign_access.c | 97 ++++++++++++++++++++++++++++-
+ 1 file changed, 96 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/mm/pcie_unalign_access.c b/arch/arm64/mm/pcie_unalign_access.c
+index f7c948985296..6dfcd4929a77 100644
+--- a/arch/arm64/mm/pcie_unalign_access.c
++++ b/arch/arm64/mm/pcie_unalign_access.c
+@@ -30,6 +30,101 @@ static int ldst_type_pair(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
+ 		return align_ldst_pair(insn, regs);
+ }
+ 
++static int align_ldst_imm_new(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	bool wback = !(insn & BIT(24)) && !!(insn & BIT(10));
++	bool postindex = wback && !(insn & BIT(11));
++	int scale = size;
++	u64 offset;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	bool is_store;
++	bool is_signed;
++	int regsize;
++	int datasize;
++	u64 address;
++	u64 data;
++
++	if (!(insn & BIT(24))) {
++		u64 uoffset =
++			aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++		offset = sign_extend64(uoffset, 8);
++	} else {
++		offset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_12, insn);
++		offset <<= scale;
++	}
++
++	if ((opc & 0x2) == 0) {
++		/* store or zero-extending load */
++		is_store = !(opc & 0x1);
++		regsize = size == 0x3 ? 64 : 32;
++		is_signed = false;
++	} else {
++		if (size == 0x3) {
++			if (FIELD_GET(GENMASK(11, 10), insn) == 0 && (opc & 0x1) == 0) {
++				/* prefetch */
++				return 0;
++			} else {
++				/* undefined */
++				return 1;
++			}
++		} else {
++			/* sign-extending load */
++			is_store = false;
++			if (size == 0x2 && (opc & 0x1) == 0x1) {
++				/* undefined */
++				return 1;
++			}
++			regsize = (opc & 0x1) == 0x1 ? 32 : 64;
++			is_signed = true;
++		}
++	}
++
++	datasize = 8 << scale;
++
++	if (wback && n == t && n != 31)
++		return 1;
++
++	address = regs_get_register(regs, n << 3);
++
++	if (!postindex)
++		address += offset;
++	printk("{%s] addr:%llx, offset:%llx\n", __func__, address, offset);
++
++	if (is_store) {
++		data = pt_regs_read_reg(regs, t);
++		if (align_store(address, datasize / 8, data))
++			return 1;
++	} else {
++		if (align_load(address, datasize / 8, &data))
++			return 1;
++		if (is_signed) {
++			if (regsize == 32)
++				data = sign_extend32(data, datasize - 1);
++			else
++				data = sign_extend64(data, datasize - 1);
++		}
++		pt_regs_write_reg(regs, t, data);
++	}
++
++	if (wback) {
++		if (postindex)
++			address += offset;
++		if (n == 31)
++			regs->sp = address;
++		else
++			pt_regs_write_reg(regs, n, address);
++	}
++
++	return 0;
++}
++
+ /*
+  * |------+-----+-----+--------+-----+----------------------------------------------|
+  * | op0  | op1 | op2 |    op3 | op4 | Decode group                                 |
+@@ -46,7 +141,7 @@ static int ldst_type_imm(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
+ 	if (insn & BIT(26))
+ 		return align_ldst_imm_simdfp(insn, regs);
+ 	else
+-		return align_ldst_imm(insn, regs);
++		return align_ldst_imm_new(insn, regs);
+ }
+ 
+ /*
+-- 
+2.39.3
+

--- a/v5.10/0007-arm64-add-unprivileged-instruction-support.patch
+++ b/v5.10/0007-arm64-add-unprivileged-instruction-support.patch
@@ -1,0 +1,335 @@
+From 0fcf6783cf466982886988777a47fdbd503202bc Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Mon, 9 May 2022 11:20:06 +0000
+Subject: [PATCH 07/10] arm64: add unprivileged instruction support
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/mm/pcie_unalign_access.c | 304 +++++++++++++++++++++++++++-
+ 1 file changed, 303 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/mm/pcie_unalign_access.c b/arch/arm64/mm/pcie_unalign_access.c
+index 6dfcd4929a77..835bbdee8882 100644
+--- a/arch/arm64/mm/pcie_unalign_access.c
++++ b/arch/arm64/mm/pcie_unalign_access.c
+@@ -174,6 +174,308 @@ static int ldst_type_vector_single(struct ldst_filter *f, u32 insn, struct pt_re
+ 	return align_ldst_vector_single(insn, regs);
+ }
+ 
++static int ldst_unpri_sttrb(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	data = pt_regs_read_reg(regs, t);
++
++	/* 3) store it now */
++	return align_store(address, 1, data);
++}
++
++static int ldst_unpri_ldtrb(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data = 0;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	align_load(address, 1, &data);
++	data = sign_extend64(data, 64 - 1);
++
++	/* 3) store it now */
++	pt_regs_write_reg(regs, t, data);
++	return 0;
++}
++
++static int ldst_unpri_ldtrsb_64(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data = 0;
++	int regsize = 64;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	align_load(address, 1, &data);
++
++	/* 64bit or 32 bit? check it with opc[0] */
++	if (insn & BIT(22))
++		regsize = 32;
++	data = sign_extend32(data, regsize - 1);
++
++	/* 3) store it now */
++	pt_regs_write_reg(regs, t, data);
++	return 0;
++}
++
++static int ldst_unpri_sttrh(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	data = pt_regs_read_reg(regs, t);
++
++	/* 3) store it now */
++	return align_store(address, 2, data);
++}
++
++static int ldst_unpri_ldtrh(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data = 0;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	align_load(address, 2, &data);
++	data = sign_extend64(data, 64 - 1);
++
++	/* 3) store it now */
++	pt_regs_write_reg(regs, t, data);
++	return 0;
++}
++
++static int ldst_unpri_ldtrsh(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data = 0;
++	int regsize = 64;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	align_load(address, 2, &data);
++
++	/* 64bit or 32 bit? check it with opc[0] */
++	if (insn & BIT(22))
++		regsize = 32;
++	data = sign_extend32(data, regsize - 1);
++
++	/* 3) store it now */
++	pt_regs_write_reg(regs, t, data);
++	return 0;
++}
++
++static int ldst_unpri_sttr(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data;
++	int scale;
++	int datasize;
++	const u32 SIZE = GENMASK(31, 30);
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	data = pt_regs_read_reg(regs, t);
++
++	/* 3) store it now */
++	scale = FIELD_GET(SIZE, insn);
++	datasize = 8 << scale;
++	return align_store(address, datasize / 8, data);
++}
++
++/* 0xf8400946 */
++static int ldst_unpri_ldtr(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data = 0;
++	int regsize = 64;
++	const u32 SIZE = GENMASK(31, 30);
++	int scale = FIELD_GET(SIZE, insn);
++	int datasize = 8 << scale;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	align_load(address, datasize / 8, &data);
++
++	/* 64bit or 32 bit? */
++	if (scale != 3)
++		regsize = 32;
++
++	/* 3) store it now */
++	pt_regs_write_reg(regs, t, data);
++	return 0;
++}
++
++static int ldst_unpri_ldtrsw(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data = 0;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	align_load(address, 4, &data);
++	data = sign_extend32(data, 64 - 1);
++
++	/* 3) store it now */
++	pt_regs_write_reg(regs, t, data);
++	return 0;
++}
++#define REG_UNPRI_MASK (BIT(31)| BIT(31) | BIT(26) | BIT(22) | BIT(23))
++static const struct ldst_filter ldst_reg_unpri[] = {
++	{
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= 0,
++		.name		= "STTRB",
++		.handler	= ldst_unpri_sttrb,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(22),
++		.name		= "LDTRB",
++		.handler	= ldst_unpri_ldtrb,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(23),
++		.name		= "LDTRSB - 64bit variant",
++		.handler	= ldst_unpri_ldtrsb_64,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(23) | BIT(22),
++		.name		= "LDTRSB - 32bit variant",
++		.handler	= ldst_unpri_ldtrsb_64,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(30),
++		.name		= "STTRH",
++		.handler	= ldst_unpri_sttrh,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(30) | BIT(22),
++		.name		= "LDTRH",
++		.handler	= ldst_unpri_ldtrh,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(30) | BIT(23),
++		.name		= "LDTRSH - 64bit variant",
++		.handler	= ldst_unpri_ldtrsh,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(30) | BIT(23) | BIT(22),
++		.name		= "LDTRSH - 32bit variant",
++		.handler	= ldst_unpri_ldtrsh,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(31),
++		.name		= "STTR - 32bit variant",
++		.handler	= ldst_unpri_sttr,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(31),
++		.name		= "LDTR - 32bit variant",
++		.handler	= ldst_unpri_ldtr,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(31) | BIT(23),
++		.name		= "LDTRSW",
++		.handler	= ldst_unpri_ldtrsw,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(31) | BIT(30),
++		.name		= "STTR - 64bit variant",
++		.handler	= ldst_unpri_sttr,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(31) | BIT(30) | BIT(22),
++		.name		= "LDTR - 64bit variant",
++		.handler	= ldst_unpri_ldtr,
++	},
++};
++
++/* Return 0 on success, return 1 on failure. */
++static int ldst_reg_unprivileged(struct ldst_filter *of, u32 insn, struct pt_regs *regs)
++{
++	int i;
++	struct ldst_filter *f;
++
++	for (i = 0; i < ARRAY_SIZE(ldst_reg_unpri); i++) {
++		f = (struct ldst_filter *)&ldst_reg_unpri[i];
++
++		/* Find the correct hander */
++		if ((f->mask & insn) == f->arm_code) {
++			pr_debug("insn:%x, (%s)\n", insn, f->name);
++			return f->handler(f, insn, regs);
++		}
++	}
++	return 1;
++}
++
+ /* Please see the C4.1.66 */
+ static const struct ldst_filter ldst_filters[] = {
+ 	{
+@@ -281,7 +583,7 @@ static const struct ldst_filter ldst_filters[] = {
+ 		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
+ 		.arm_code	= BIT(29) | BIT(28) | BIT(11),
+ 		.name		= "Load/store register (unprivileged)",
+-		.handler	= ldst_default,
++		.handler	= ldst_reg_unprivileged,
+ 	}, {
+ 		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
+ 		.arm_code	= BIT(29) | BIT(28) | BIT(11) | BIT(10),
+-- 
+2.39.3
+

--- a/v5.10/0008-arm64-pcie-wc-print-out-the-error-log.patch
+++ b/v5.10/0008-arm64-pcie-wc-print-out-the-error-log.patch
@@ -1,0 +1,31 @@
+From 5aa2c4feb431ba532c5865d73d067395285bee6a Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Tue, 4 Jul 2023 14:15:44 +0800
+Subject: [PATCH 08/10] arm64: pcie-wc: print out the error log
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/mm/pcie_unalign_access.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm64/mm/pcie_unalign_access.c b/arch/arm64/mm/pcie_unalign_access.c
+index 835bbdee8882..52475f910154 100644
+--- a/arch/arm64/mm/pcie_unalign_access.c
++++ b/arch/arm64/mm/pcie_unalign_access.c
+@@ -623,8 +623,11 @@ static int align_ldst_new(u32 insn, struct pt_regs *regs)
+ 
+ 		/* Find the correct hander */
+ 		if ((f->mask & insn) == f->arm_code) {
+-			pr_debug("insn:%x, (%s)\n", insn, f->name);
+-			return f->handler(f, insn, regs);
++			int ret = f->handler(f, insn, regs);
++
++			if (ret)
++				pr_info("Failed in handling insn:%x, (%s)\n", insn, f->name);
++			return ret;
+ 		}
+ 	}
+ 
+-- 
+2.39.3
+

--- a/v5.10/0009-pcie-wc-add-support-for-fc2c6b41.patch
+++ b/v5.10/0009-pcie-wc-add-support-for-fc2c6b41.patch
@@ -1,0 +1,119 @@
+From 832c5521be20616fc5bc3798b08df7bfe1b9a833 Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Wed, 5 Jul 2023 09:30:43 +0800
+Subject: [PATCH 09/10] pcie-wc: add support for fc2c6b41
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/mm/pcie_unalign_access.c | 81 ++++++++++++++++++++++++++++-
+ 1 file changed, 80 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/mm/pcie_unalign_access.c b/arch/arm64/mm/pcie_unalign_access.c
+index 52475f910154..639c6a48ddee 100644
+--- a/arch/arm64/mm/pcie_unalign_access.c
++++ b/arch/arm64/mm/pcie_unalign_access.c
+@@ -144,6 +144,84 @@ static int ldst_type_imm(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
+ 		return align_ldst_imm_new(insn, regs);
+ }
+ 
++/* handle for fc2c6b41 */
++static int align_ldst_regoff_simdfp_new(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++	const u32 OPTION = GENMASK(15, 13);
++	const u32 S = BIT(12);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	u32 option = FIELD_GET(OPTION, insn);
++	u32 s = FIELD_GET(S, insn);
++	int scale = (opc & 0x2) << 1 | size;
++	int extend_len = (option & 0x1) ? 64 : 32;
++	bool extend_unsigned = !(option & 0x4);
++	int shift = s ? scale : 0;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int m = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RM, insn);
++	bool is_store = !(opc & BIT(0));
++	int datasize;
++	u64 offset;
++	u64 address;
++	u64 data_d0, data_d1;
++
++	/*
++	if ((opc & 0x2) == 0)
++		return 1;
++	*/
++
++	datasize = 8 << scale;
++
++	if (n == t && n != 31)
++		return 1;
++
++	offset = pt_regs_read_reg(regs, m);
++	if (extend_len == 32) {
++		offset &= (u32)~0;
++		if (!extend_unsigned)
++			sign_extend64(offset, 31);
++	}
++	offset <<= shift;
++
++	address = regs_get_register(regs, n << 3) + offset;
++
++	if (is_store) {
++		data_d0 = get_vn_dt(t, 0);
++		if (datasize == 128) {
++			data_d1 = get_vn_dt(t, 1);
++			if (align_store(address, 8, data_d0) ||
++			    align_store(address + 8, 8, data_d1))
++				return 1;
++		} else if (datasize == 64) {
++			/* fc2c6b41 should come here. */
++			if (align_store(address, 8, data_d0))
++				return 1;
++		} else {
++			if (align_store(address, datasize / 8, data_d0))
++				return 1;
++		}
++	} else {
++		if (datasize == 128) {
++			if (align_load(address, 8, &data_d0) ||
++			    align_load(address + 8, 8, &data_d1))
++				return 1;
++		} else {
++			if (align_load(address, datasize / 8, &data_d0))
++				return 1;
++			data_d1 = 0;
++		}
++		set_vn_dt(t, 0, data_d0);
++		set_vn_dt(t, 1, data_d1);
++	}
++
++	return 0;
++}
++
+ /*
+  * |------+-----+-----+--------+-----+---------------------------------------|
+  * | op0  | op1 | op2 |    op3 | op4 |                                       |
+@@ -155,7 +233,7 @@ static int ldst_type_regoff(struct ldst_filter *f, u32 insn, struct pt_regs *reg
+ {
+ 	/* The bit 26 is used for SIMD only, please see the spec */
+ 	if (insn & BIT(26))
+-		return align_ldst_regoff_simdfp(insn, regs);
++		return align_ldst_regoff_simdfp_new(insn, regs);
+ 	else
+ 		return align_ldst_regoff(insn, regs);
+ }
+@@ -625,6 +703,7 @@ static int align_ldst_new(u32 insn, struct pt_regs *regs)
+ 		if ((f->mask & insn) == f->arm_code) {
+ 			int ret = f->handler(f, insn, regs);
+ 
++			pr_debug("handling insn:%x, (%s)\n", insn, f->name);
+ 			if (ret)
+ 				pr_info("Failed in handling insn:%x, (%s)\n", insn, f->name);
+ 			return ret;
+-- 
+2.39.3
+

--- a/v5.10/0010-arm64-pcie-wc-fix-the-typo-for-f8400865.patch
+++ b/v5.10/0010-arm64-pcie-wc-fix-the-typo-for-f8400865.patch
@@ -1,0 +1,26 @@
+From 9dac894456f679bacbdd519bd7a676efc8c65c57 Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Fri, 28 Jul 2023 15:37:35 +0800
+Subject: [PATCH 10/10] arm64: pcie-wc: fix the typo for f8400865
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/mm/pcie_unalign_access.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/mm/pcie_unalign_access.c b/arch/arm64/mm/pcie_unalign_access.c
+index 639c6a48ddee..66826dfe4e9c 100644
+--- a/arch/arm64/mm/pcie_unalign_access.c
++++ b/arch/arm64/mm/pcie_unalign_access.c
+@@ -466,7 +466,7 @@ static int ldst_unpri_ldtrsw(struct ldst_filter *f, u32 insn, struct pt_regs *re
+ 	pt_regs_write_reg(regs, t, data);
+ 	return 0;
+ }
+-#define REG_UNPRI_MASK (BIT(31)| BIT(31) | BIT(26) | BIT(22) | BIT(23))
++#define REG_UNPRI_MASK (BIT(31)| BIT(30) | BIT(26) | BIT(22) | BIT(23))
+ static const struct ldst_filter ldst_reg_unpri[] = {
+ 	{
+ 		.mask		= REG_UNPRI_MASK,
+-- 
+2.39.3
+

--- a/v5.10/0011-Fix-ttbr0-emulation-of-dc-zva.patch
+++ b/v5.10/0011-Fix-ttbr0-emulation-of-dc-zva.patch
@@ -1,0 +1,28 @@
+From 45cd67bdcf313147e4e91b1512e79cd4eb58f108 Mon Sep 17 00:00:00 2001
+From: D Scott Phillips <scott@os.amperecomputing.com>
+Date: Thu, 20 Mar 2025 07:45:49 -0700
+Subject: [PATCH 1/1] Fix ttbr0 emulation of dc zva
+
+The loop to emulate dc zva in the ttbr0 range was mistakenly not
+updating the address, so not actually clearing all the data in the dc
+zva access, but only the first byte.
+---
+ arch/arm64/mm/fault.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/mm/fault.c b/arch/arm64/mm/fault.c
+index ab971505d5b1..e1d7dbaf711b 100644
+--- a/arch/arm64/mm/fault.c
++++ b/arch/arm64/mm/fault.c
+@@ -708,7 +708,7 @@ static int align_dc_zva(unsigned long addr, struct pt_regs *regs)
+ 	addr &= ~(sz - 1);
+ 	if (is_ttbr0_addr(addr)) {
+ 		for (; sz; sz--) {
+-			if (align_store(addr, 1, 0))
++			if (align_store(addr++, 1, 0))
+ 				return 1;
+ 		}
+ 	} else
+-- 
+2.27.0
+

--- a/v5.10/0012-Fix-load-in-align_ldst_regoff.patch
+++ b/v5.10/0012-Fix-load-in-align_ldst_regoff.patch
@@ -1,0 +1,25 @@
+From 04f845a9d65826ac7e061d7b119f401e4de343c2 Mon Sep 17 00:00:00 2001
+From: davidz-ampere <>
+Date: Mon, 24 Mar 2025 22:52:47 -0400
+Subject: [PATCH 1/1] Fix load in align_ldst_regoff
+
+Data is not written back to the register and will cause data mismatch.
+---
+ arch/arm64/mm/fault.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/mm/fault.c b/arch/arm64/mm/fault.c
+index e1d7dbaf711b..3de669a618a2 100644
+--- a/arch/arm64/mm/fault.c
++++ b/arch/arm64/mm/fault.c
+@@ -1032,6 +1032,7 @@ static int align_ldst_regoff(u32 insn, struct pt_regs *regs)
+ 			else
+ 				data = sign_extend64(data, datasize - 1);
+ 		}
++		pt_regs_write_reg(regs, t, data);
+ 	}
+ 
+ 	return 0;
+-- 
+2.27.0
+

--- a/v5.15/0001-arm64-Work-around-Ampere-Altra-erratum-82288-PCIE_65.patch
+++ b/v5.15/0001-arm64-Work-around-Ampere-Altra-erratum-82288-PCIE_65.patch
@@ -1,0 +1,171 @@
+From 26863483bf14e08352b90d780788b385a3bc6192 Mon Sep 17 00:00:00 2001
+From: D Scott Phillips <scott@os.amperecomputing.com>
+Date: Fri, 13 Nov 2020 08:25:23 -0800
+Subject: [PATCH 01/10] arm64: Work around Ampere Altra erratum #82288 PCIE_65
+
+Altra's PCIe controller may generate incorrect addresses when receiving
+writes from the CPU with a discontiguous set of byte enables. Attempt to
+work around this by handing out Device-nGnRE maps instead of Normal
+Non-cacheable maps for PCIe memory areas.
+
+Signed-off-by: D Scott Phillips <scott@os.amperecomputing.com>
+---
+ Documentation/arm64/silicon-errata.rst |  3 +++
+ arch/arm64/Kconfig                     |  9 +++++++++
+ arch/arm64/include/asm/pci.h           |  5 +++++
+ arch/arm64/include/asm/pgtable.h       | 26 +++++++++++++++++++++-----
+ arch/arm64/mm/ioremap.c                | 18 ++++++++++++++++++
+ drivers/pci/quirks.c                   |  9 +++++++++
+ 6 files changed, 65 insertions(+), 5 deletions(-)
+
+diff --git a/Documentation/arm64/silicon-errata.rst b/Documentation/arm64/silicon-errata.rst
+index 7c1750bcc5bd..3463b9ef9ccd 100644
+--- a/Documentation/arm64/silicon-errata.rst
++++ b/Documentation/arm64/silicon-errata.rst
+@@ -52,6 +52,9 @@ stable kernels.
+ | Allwinner      | A64/R18         | UNKNOWN1        | SUN50I_ERRATUM_UNKNOWN1     |
+ +----------------+-----------------+-----------------+-----------------------------+
+ +----------------+-----------------+-----------------+-----------------------------+
++| Ampere         | Altra           | #82288          | ALTRA_ERRATUM_82288         |
+++----------------+-----------------+-----------------+-----------------------------+
+++----------------+-----------------+-----------------+-----------------------------+
+ | ARM            | Cortex-A53      | #826319         | ARM64_ERRATUM_826319        |
+ +----------------+-----------------+-----------------+-----------------------------+
+ | ARM            | Cortex-A53      | #827319         | ARM64_ERRATUM_827319        |
+diff --git a/arch/arm64/Kconfig b/arch/arm64/Kconfig
+index 8b6f090e0364..2cb5297c9a37 100644
+--- a/arch/arm64/Kconfig
++++ b/arch/arm64/Kconfig
+@@ -358,6 +358,15 @@ menu "ARM errata workarounds via the alternatives framework"
+ config ARM64_WORKAROUND_CLEAN_CACHE
+ 	bool
+ 
++config ALTRA_ERRATUM_82288
++	bool "Ampere Altra: 82288: PCIE_65: PCIe Root Port outbound write combining issue"
++	default y
++	help
++	  This option adds an alternative code sequence to work around
++	  Ampere Altra erratum 82288.
++
++	  If unsure, say Y.
++
+ config ARM64_ERRATUM_826319
+ 	bool "Cortex-A53: 826319: System might deadlock if a write cannot complete until read data is accepted"
+ 	default y
+diff --git a/arch/arm64/include/asm/pci.h b/arch/arm64/include/asm/pci.h
+index b33ca260e3c9..fa9d32710e60 100644
+--- a/arch/arm64/include/asm/pci.h
++++ b/arch/arm64/include/asm/pci.h
+@@ -17,7 +17,12 @@
+ #define pcibios_assign_all_busses() \
+ 	(pci_has_flag(PCI_REASSIGN_ALL_BUS))
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++extern bool __read_mostly have_altra_erratum_82288;
++#else
+ #define arch_can_pci_mmap_wc() 1
++#endif
++
+ #define ARCH_GENERIC_PCI_MMAP_RESOURCE	1
+ 
+ extern int isa_dma_bridge_buggy;
+diff --git a/arch/arm64/include/asm/pgtable.h b/arch/arm64/include/asm/pgtable.h
+index ed57717cd004..e3f3bbe34cfe 100644
+--- a/arch/arm64/include/asm/pgtable.h
++++ b/arch/arm64/include/asm/pgtable.h
+@@ -221,11 +221,6 @@ static inline pte_t pte_mkyoung(pte_t pte)
+ 	return set_pte_bit(pte, __pgprot(PTE_AF));
+ }
+ 
+-static inline pte_t pte_mkspecial(pte_t pte)
+-{
+-	return set_pte_bit(pte, __pgprot(PTE_SPECIAL));
+-}
+-
+ static inline pte_t pte_mkcont(pte_t pte)
+ {
+ 	pte = set_pte_bit(pte, __pgprot(PTE_CONT));
+@@ -524,6 +519,27 @@ static inline pmd_t pmd_mkdevmap(pmd_t pmd)
+ 	__pgprot_modify(prot, PTE_ATTRINDX_MASK, \
+ 			PTE_ATTRINDX(MT_NORMAL_NC) | PTE_PXN | PTE_UXN)
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++extern bool have_altra_erratum_82288;
++#endif
++
++static inline pte_t pte_mkspecial(pte_t pte)
++{
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++	phys_addr_t phys = __pte_to_phys(pte);
++	pgprot_t prot = __pgprot(pte_val(pte) & ~PTE_ADDR_MASK);
++
++	if (unlikely(have_altra_erratum_82288) &&
++	    (phys < 0x80000000 ||
++	     (phys >= 0x200000000000 && phys < 0x400000000000) ||
++	     (phys >= 0x600000000000 && phys < 0x800000000000))) {
++		pte = __pte(__phys_to_pte_val(phys) | pgprot_val(pgprot_device(prot)));
++	}
++#endif
++
++	return set_pte_bit(pte, __pgprot(PTE_SPECIAL));
++}
++
+ #define __HAVE_PHYS_MEM_ACCESS_PROT
+ struct file;
+ extern pgprot_t phys_mem_access_prot(struct file *file, unsigned long pfn,
+diff --git a/arch/arm64/mm/ioremap.c b/arch/arm64/mm/ioremap.c
+index b21f91cd830d..bdc34c4d7ff5 100644
+--- a/arch/arm64/mm/ioremap.c
++++ b/arch/arm64/mm/ioremap.c
+@@ -17,6 +17,19 @@
+ #include <asm/fixmap.h>
+ #include <asm/tlbflush.h>
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++bool have_altra_erratum_82288 __read_mostly;
++EXPORT_SYMBOL(have_altra_erratum_82288);
++
++static bool is_altra_pci(phys_addr_t phys_addr, size_t size)
++{
++	phys_addr_t end = phys_addr + size;
++	return (phys_addr < 0x80000000 ||
++		(end > 0x200000000000 && phys_addr < 0x400000000000) ||
++		(end > 0x600000000000 && phys_addr < 0x800000000000));
++}
++#endif
++
+ static void __iomem *__ioremap_caller(phys_addr_t phys_addr, size_t size,
+ 				      pgprot_t prot, void *caller)
+ {
+@@ -52,6 +65,11 @@ static void __iomem *__ioremap_caller(phys_addr_t phys_addr, size_t size,
+ 	addr = (unsigned long)area->addr;
+ 	area->phys_addr = phys_addr;
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++	if (unlikely(have_altra_erratum_82288 && is_altra_pci(phys_addr, size)))
++		prot = pgprot_device(prot);
++#endif
++
+ 	err = ioremap_page_range(addr, addr + size, phys_addr, prot);
+ 	if (err) {
+ 		vunmap((void *)addr);
+diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
+index 4893b1e82403..41b403d288c3 100644
+--- a/drivers/pci/quirks.c
++++ b/drivers/pci/quirks.c
+@@ -5821,3 +5821,12 @@ static void nvidia_ion_ahci_fixup(struct pci_dev *pdev)
+ 	pdev->dev_flags |= PCI_DEV_FLAGS_HAS_MSI_MASKING;
+ }
+ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_NVIDIA, 0x0ab8, nvidia_ion_ahci_fixup);
++
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++static void quirk_altra_erratum_82288(struct pci_dev *dev)
++{
++	pr_info_once("Write combining PCI maps disabled due to hardware erratum\n");
++	have_altra_erratum_82288 = true;
++}
++DECLARE_PCI_FIXUP_EARLY(PCI_VENDOR_ID_AMPERE, 0xe100, quirk_altra_erratum_82288);
++#endif
+-- 
+2.39.3
+

--- a/v5.15/0002-arm64-Add-a-fixup-handler-for-alignment-faults-in-aa.patch
+++ b/v5.15/0002-arm64-Add-a-fixup-handler-for-alignment-faults-in-aa.patch
@@ -1,0 +1,824 @@
+From eef23c8adc9f6a30a273b7cca07d503221158c69 Mon Sep 17 00:00:00 2001
+From: D Scott Phillips <scott@os.amperecomputing.com>
+Date: Thu, 10 Dec 2020 00:07:19 -0800
+Subject: [PATCH 02/10] arm64: Add a fixup handler for alignment faults in
+ aarch64 code
+
+A later patch will hand out Device memory in some cases to code
+which expects a Normal memory type, as an errata workaround.
+Unaligned accesses to Device memory will fault though, so here we
+add a fixup handler to emulate faulting accesses, at a performance
+penalty.
+
+Many of the instructions in the Loads and Stores group are supported,
+but these groups are not handled here:
+
+ * Advanced SIMD load/store multiple structures
+ * Advanced SIMD load/store multiple structures (post-indexed)
+ * Advanced SIMD load/store single structure
+ * Advanced SIMD load/store single structure (post-indexed)
+ * Load/store memory tags
+ * Load/store exclusive
+ * LDAPR/STLR (unscaled immediate)
+ * Load register (literal) [cannot Alignment fault]
+ * Load/store register (unprivileged)
+ * Atomic memory operations
+ * Load/store register (pac)
+
+Instruction implementations are translated from the Exploration tools'
+ASL specifications.
+
+Signed-off-by: D Scott Phillips <scott@os.amperecomputing.com>
+---
+ arch/arm64/include/asm/insn.h |   1 +
+ arch/arm64/mm/fault.c         | 745 ++++++++++++++++++++++++++++++++++
+ 2 files changed, 746 insertions(+)
+
+diff --git a/arch/arm64/include/asm/insn.h b/arch/arm64/include/asm/insn.h
+index b02f0c328c8e..51f8e27a923a 100644
+--- a/arch/arm64/include/asm/insn.h
++++ b/arch/arm64/include/asm/insn.h
+@@ -387,6 +387,7 @@ __AARCH64_INSN_FUNCS(sb,	0xFFFFFFFF, 0xD50330FF)
+ __AARCH64_INSN_FUNCS(clrex,	0xFFFFF0FF, 0xD503305F)
+ __AARCH64_INSN_FUNCS(ssbb,	0xFFFFFFFF, 0xD503309F)
+ __AARCH64_INSN_FUNCS(pssbb,	0xFFFFFFFF, 0xD503349F)
++__AARCH64_INSN_FUNCS(dc_zva,	0xFFFFFFE0, 0xD50B7420)
+ 
+ #undef	__AARCH64_INSN_FUNCS
+ 
+diff --git a/arch/arm64/mm/fault.c b/arch/arm64/mm/fault.c
+index 9ae24e3b72be..d3998c789fcd 100644
+--- a/arch/arm64/mm/fault.c
++++ b/arch/arm64/mm/fault.c
+@@ -5,6 +5,7 @@
+  * Copyright (C) 1995  Linus Torvalds
+  * Copyright (C) 1995-2004 Russell King
+  * Copyright (C) 2012 ARM Ltd.
++ * Copyright (C) 2020 Ampere Computing LLC
+  */
+ 
+ #include <linux/acpi.h>
+@@ -36,6 +37,7 @@
+ #include <asm/esr.h>
+ #include <asm/kprobes.h>
+ #include <asm/mte.h>
++#include <asm/patching.h>
+ #include <asm/processor.h>
+ #include <asm/sysreg.h>
+ #include <asm/system_misc.h>
+@@ -683,9 +685,752 @@ static int __kprobes do_translation_fault(unsigned long far,
+ 	return 0;
+ }
+ 
++static int copy_from_user_io(void *to, const void __user *from, unsigned long n)
++{
++	const u8 __user *src = from;
++	u8 *dest = to;
++
++	for (; n; n--)
++		if (get_user(*dest++, src++))
++			break;
++	return n;
++}
++
++static int copy_to_user_io(void __user *to, const void *from, unsigned long n)
++{
++	const u8 *src = from;
++	u8 __user *dest = to;
++
++	for (; n; n--)
++		if (put_user(*src++, dest++))
++			break;
++	return n;
++}
++
++static int align_load(unsigned long addr, int sz, u64 *out)
++{
++	union {
++		u8 d8;
++		u16 d16;
++		u32 d32;
++		u64 d64;
++		char c[8];
++	} data;
++
++	if (sz != 1 && sz != 2 && sz != 4 && sz != 8)
++		return 1;
++	if (is_ttbr0_addr(addr)) {
++		if (copy_from_user_io(data.c, (const void __user *)addr, sz))
++			return 1;
++	} else
++		memcpy_fromio(data.c, (const void __iomem *)addr, sz);
++	switch (sz) {
++	case 1:
++		*out = data.d8;
++		break;
++	case 2:
++		*out = data.d16;
++		break;
++	case 4:
++		*out = data.d32;
++		break;
++	case 8:
++		*out = data.d64;
++		break;
++	default:
++		return 1;
++	}
++	return 0;
++}
++
++static int align_store(unsigned long addr, int sz, u64 val)
++{
++	union {
++		u8 d8;
++		u16 d16;
++		u32 d32;
++		u64 d64;
++		char c[8];
++	} data;
++
++	switch (sz) {
++	case 1:
++		data.d8 = val;
++		break;
++	case 2:
++		data.d16 = val;
++		break;
++	case 4:
++		data.d32 = val;
++		break;
++	case 8:
++		data.d64 = val;
++		break;
++	default:
++		return 1;
++	}
++	if (is_ttbr0_addr(addr)) {
++		if (copy_to_user_io((void __user *)addr, data.c, sz))
++			return 1;
++	} else
++		memcpy_toio((void __iomem *)addr, data.c, sz);
++	return 0;
++}
++
++static int align_dc_zva(unsigned long addr, struct pt_regs *regs)
++{
++	int bs = read_cpuid(DCZID_EL0) & 0xf;
++	int sz = 1 << (bs + 2);
++
++	addr &= ~(sz - 1);
++	if (is_ttbr0_addr(addr)) {
++		for (; sz; sz--) {
++			if (align_store(addr, 1, 0))
++				return 1;
++		}
++	} else
++		memset_io((void *)addr, 0, sz);
++	return 0;
++}
++
++static u64 get_vn_dt(int n, int t) {
++	u64 res;
++
++	switch (n) {
++#define V(n)						\
++	case n:						\
++		asm("cbnz %w1, 1f\n\t"			\
++		    "mov %0, v"#n".d[0]\n\t"		\
++		    "b 2f\n\t"				\
++		    "1: mov %0, v"#n".d[1]\n\t"		\
++		    "2:" : "=r" (res) : "r" (t));	\
++		break
++	V( 0); V( 1); V( 2); V( 3); V( 4); V( 5); V( 6); V( 7);
++	V( 8); V( 9); V(10); V(11); V(12); V(13); V(14); V(15);
++	V(16); V(17); V(18); V(19); V(20); V(21); V(22); V(23);
++	V(24); V(25); V(26); V(27); V(28); V(29); V(30); V(31);
++#undef V
++	default:
++		res = 0;
++		break;
++	}
++	return res;
++}
++
++static void set_vn_dt(int n, int t, u64 val) {
++	switch (n) {
++#define V(n)						\
++	case n:						\
++		asm("cbnz %w1, 1f\n\t"			\
++		    "mov v"#n".d[0], %0\n\t"		\
++		    "b 2f\n\t"				\
++		    "1: mov v"#n".d[1], %0\n\t"		\
++		    "2:" :: "r" (val), "r" (t));	\
++		break
++	V( 0); V( 1); V( 2); V( 3); V( 4); V( 5); V( 6); V( 7);
++	V( 8); V( 9); V(10); V(11); V(12); V(13); V(14); V(15);
++	V(16); V(17); V(18); V(19); V(20); V(21); V(22); V(23);
++	V(24); V(25); V(26); V(27); V(28); V(29); V(30); V(31);
++#undef Q
++	default:
++		break;
++	}
++}
++
++static int align_ldst_pair(u32 insn, struct pt_regs *regs)
++{
++	const u32 OPC = GENMASK(31, 30);
++	const u32 L_MASK = BIT(22);
++
++	int opc = FIELD_GET(OPC, insn);
++	int L = FIELD_GET(L_MASK, insn);
++
++	bool wback = !!(insn & BIT(23));
++	bool postindex = !(insn & BIT(24));
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int t2 = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT2, insn);
++	bool is_store = !L;
++	bool is_signed = !!(opc & 1);
++	int scale = 2 + (opc >> 1);
++	int datasize = 8 << scale;
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_7, insn);
++	s64 offset = sign_extend64(uoffset, 6) << scale;
++	u64 address;
++	u64 data1, data2;
++	u64 dbytes;
++
++	if ((is_store && (opc & 1)) || opc == 3)
++		return 1;
++
++	if (wback && (t == n || t2 == n) && n != 31)
++		return 1;
++
++	if (!is_store && t == t2)
++		return 1;
++
++	dbytes = datasize / 8;
++
++	address = regs_get_register(regs, n << 3);
++
++	if (!postindex)
++		address += offset;
++
++	if (is_store) {
++		data1 = pt_regs_read_reg(regs, t);
++		data2 = pt_regs_read_reg(regs, t2);
++		if (align_store(address, dbytes, data1) ||
++		    align_store(address + dbytes, dbytes, data2))
++			return 1;
++	} else {
++		if (align_load(address, dbytes, &data1) ||
++		    align_load(address + dbytes, dbytes, &data2))
++			return 1;
++		if (is_signed) {
++			data1 = sign_extend64(data1, datasize - 1);
++			data2 = sign_extend64(data2, datasize - 1);
++		}
++		pt_regs_write_reg(regs, t, data1);
++		pt_regs_write_reg(regs, t2, data2);
++	}
++
++	if (wback) {
++		if (postindex)
++			address += offset;
++		if (n == 31)
++			regs->sp = address;
++		else
++			pt_regs_write_reg(regs, n, address);
++	}
++
++	return 0;
++}
++
++static int align_ldst_pair_simdfp(u32 insn, struct pt_regs *regs)
++{
++	const u32 OPC = GENMASK(31, 30);
++	const u32 L_MASK = BIT(22);
++
++	int opc = FIELD_GET(OPC, insn);
++	int L = FIELD_GET(L_MASK, insn);
++
++	bool wback = !!(insn & BIT(23));
++	bool postindex = !(insn & BIT(24));
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int t2 = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT2, insn);
++	bool is_store = !L;
++	int scale = 2 + opc;
++	int datasize = 8 << scale;
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_7, insn);
++	s64 offset = sign_extend64(uoffset, 6) << scale;
++	u64 address;
++	u64 data1_d0, data1_d1, data2_d0, data2_d1;
++	u64 dbytes;
++
++	if (opc == 0x3)
++		return 1;
++
++	if (!is_store && t == t2)
++		return 1;
++
++	dbytes = datasize / 8;
++
++	address = regs_get_register(regs, n << 3);
++
++	if (!postindex)
++		address += offset;
++
++	if (is_store) {
++		data1_d0 = get_vn_dt(t, 0);
++		data2_d0 = get_vn_dt(t2, 0);
++		if (datasize == 128) {
++			data1_d1 = get_vn_dt(t, 1);
++			data2_d1 = get_vn_dt(t2, 1);
++			if (align_store(address, 8, data1_d0) ||
++			    align_store(address + 8, 8, data1_d1) ||
++			    align_store(address + 16, 8, data2_d0) ||
++			    align_store(address + 24, 8, data2_d1))
++				return 1;
++		} else {
++			if (align_store(address, dbytes, data1_d0) ||
++			    align_store(address + dbytes, dbytes, data2_d0))
++				return 1;
++		}
++	} else {
++		if (datasize == 128) {
++			if (align_load(address, 8, &data1_d0) ||
++			    align_load(address + 8, 8, &data1_d1) ||
++			    align_load(address + 16, 8, &data2_d0) ||
++			    align_load(address + 24, 8, &data2_d1))
++				return 1;
++		} else {
++			if (align_load(address, dbytes, &data1_d0) ||
++			    align_load(address + dbytes, dbytes, &data2_d0))
++				return 1;
++			data1_d1 = data2_d1 = 0;
++		}
++		set_vn_dt(t, 0, data1_d0);
++		set_vn_dt(t, 1, data1_d1);
++		set_vn_dt(t2, 0, data2_d0);
++		set_vn_dt(t2, 1, data2_d1);
++	}
++
++	if (wback) {
++		if (postindex)
++			address += offset;
++		if (n == 31)
++			regs->sp = address;
++		else
++			pt_regs_write_reg(regs, n, address);
++	}
++
++	return 0;
++}
++
++static int align_ldst_regoff(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++	const u32 OPTION = GENMASK(15, 13);
++	const u32 S = BIT(12);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	u32 option = FIELD_GET(OPTION, insn);
++	u32 s = FIELD_GET(S, insn);
++	int scale = size;
++	int extend_len = (option & 0x1) ? 64 : 32;
++	bool extend_unsigned = !(option & 0x4);
++	int shift = s ? scale : 0;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int m = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RM, insn);
++	bool is_store;
++	bool is_signed;
++	int regsize;
++	int datasize;
++	u64 offset;
++	u64 address;
++	u64 data;
++
++	if ((opc & 0x2) == 0) {
++		/* store or zero-extending load */
++		is_store = !(opc & 0x1);
++		regsize = size == 0x3 ? 64 : 32;
++		is_signed = false;
++	} else {
++		if (size == 0x3) {
++			if ((opc & 0x1) == 0) {
++				/* prefetch */
++				return 0;
++			} else {
++				/* undefined */
++				return 1;
++			}
++		} else {
++			/* sign-extending load */
++			is_store = false;
++			if (size == 0x2 && (opc & 0x1) == 0x1) {
++				/* undefined */
++				return 1;
++			}
++			regsize = (opc & 0x1) == 0x1 ? 32 : 64;
++			is_signed = true;
++		}
++	}
++
++	datasize = 8 << scale;
++
++	if (n == t && n != 31)
++		return 1;
++
++	offset = pt_regs_read_reg(regs, m);
++	if (extend_len == 32) {
++		offset &= (u32)~0;
++		if (!extend_unsigned)
++			sign_extend64(offset, 31);
++	}
++	offset <<= shift;
++
++	address = regs_get_register(regs, n << 3) + offset;
++
++	if (is_store) {
++		data = pt_regs_read_reg(regs, t);
++		if (align_store(address, datasize / 8, data))
++			return 1;
++	} else {
++		if (align_load(address, datasize / 8, &data))
++			return 1;
++		if (is_signed) {
++			if (regsize == 32)
++				data = sign_extend32(data, datasize - 1);
++			else
++				data = sign_extend64(data, datasize - 1);
++		}
++	}
++
++	return 0;
++}
++
++static int align_ldst_regoff_simdfp(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++	const u32 OPTION = GENMASK(15, 13);
++	const u32 S = BIT(12);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	u32 option = FIELD_GET(OPTION, insn);
++	u32 s = FIELD_GET(S, insn);
++	int scale = (opc & 0x2) << 1 | size;
++	int extend_len = (option & 0x1) ? 64 : 32;
++	bool extend_unsigned = !(option & 0x4);
++	int shift = s ? scale : 0;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int m = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RM, insn);
++	bool is_store = !(opc & BIT(0));
++	int datasize;
++	u64 offset;
++	u64 address;
++	u64 data_d0, data_d1;
++
++	if ((opc & 0x2) == 0)
++		return 1;
++
++	datasize = 8 << scale;
++
++	if (n == t && n != 31)
++		return 1;
++
++	offset = pt_regs_read_reg(regs, m);
++	if (extend_len == 32) {
++		offset &= (u32)~0;
++		if (!extend_unsigned)
++			sign_extend64(offset, 31);
++	}
++	offset <<= shift;
++
++	address = regs_get_register(regs, n << 3) + offset;
++
++	if (is_store) {
++		data_d0 = get_vn_dt(t, 0);
++		if (datasize == 128) {
++			data_d1 = get_vn_dt(t, 1);
++			if (align_store(address, 8, data_d0) ||
++			    align_store(address + 8, 8, data_d1))
++				return 1;
++		} else {
++			if (align_store(address, datasize / 8, data_d0))
++				return 1;
++		}
++	} else {
++		if (datasize == 128) {
++			if (align_load(address, 8, &data_d0) ||
++			    align_load(address + 8, 8, &data_d1))
++				return 1;
++		} else {
++			if (align_load(address, datasize / 8, &data_d0))
++				return 1;
++			data_d1 = 0;
++		}
++		set_vn_dt(t, 0, data_d0);
++		set_vn_dt(t, 1, data_d1);
++	}
++
++	return 0;
++}
++
++static int align_ldst_imm(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	bool wback = !(insn & BIT(24)) && !!(insn & BIT(10));
++	bool postindex = wback && !(insn & BIT(11));
++	int scale = size;
++	u64 offset;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	bool is_store;
++	bool is_signed;
++	int regsize;
++	int datasize;
++	u64 address;
++	u64 data;
++
++	if (!(insn & BIT(24))) {
++		u64 uoffset =
++			aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++		offset = sign_extend64(uoffset, 8);
++	} else {
++		offset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_12, insn);
++		offset <<= scale;
++	}
++
++	if ((opc & 0x2) == 0) {
++		/* store or zero-extending load */
++		is_store = !(opc & 0x1);
++		regsize = size == 0x3 ? 64 : 32;
++		is_signed = false;
++	} else {
++		if (size == 0x3) {
++			if (FIELD_GET(GENMASK(11, 10), insn) == 0 && (opc & 0x1) == 0) {
++				/* prefetch */
++				return 0;
++			} else {
++				/* undefined */
++				return 1;
++			}
++		} else {
++			/* sign-extending load */
++			is_store = false;
++			if (size == 0x2 && (opc & 0x1) == 0x1) {
++				/* undefined */
++				return 1;
++			}
++			regsize = (opc & 0x1) == 0x1 ? 32 : 64;
++			is_signed = true;
++		}
++	}
++
++	datasize = 8 << scale;
++
++	if (n == t && n != 31)
++		return 1;
++
++	address = regs_get_register(regs, n << 3);
++
++	if (!postindex)
++		address += offset;
++
++	if (is_store) {
++		data = pt_regs_read_reg(regs, t);
++		if (align_store(address, datasize / 8, data))
++			return 1;
++	} else {
++		if (align_load(address, datasize / 8, &data))
++			return 1;
++		if (is_signed) {
++			if (regsize == 32)
++				data = sign_extend32(data, datasize - 1);
++			else
++				data = sign_extend64(data, datasize - 1);
++		}
++		pt_regs_write_reg(regs, t, data);
++	}
++
++	if (wback) {
++		if (postindex)
++			address += offset;
++		if (n == 31)
++			regs->sp = address;
++		else
++			pt_regs_write_reg(regs, n, address);
++	}
++
++	return 0;
++}
++
++static int align_ldst_imm_simdfp(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	bool wback = !(insn & BIT(24)) && !!(insn & BIT(10));
++	bool postindex = wback && !(insn & BIT(11));
++	int scale = (opc & 0x2) << 1 | size;
++	u64 offset;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	bool is_store = !(opc & BIT(0)) ;
++	int datasize;
++	u64 address;
++	u64 data_d0, data_d1;
++
++	if (scale > 4)
++		return 1;
++
++	if (!(insn & BIT(24))) {
++		u64 uoffset =
++			aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++		offset = sign_extend64(uoffset, 8);
++	} else {
++		offset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_12, insn);
++		offset <<= scale;
++	}
++
++	datasize = 8 << scale;
++
++	address = regs_get_register(regs, n << 3);
++
++	if (!postindex)
++		address += offset;
++
++	if (is_store) {
++		data_d0 = get_vn_dt(t, 0);
++		if (datasize == 128) {
++			data_d1 = get_vn_dt(t, 1);
++			if (align_store(address, 8, data_d0) ||
++			    align_store(address + 8, 8, data_d1))
++				return 1;
++		} else {
++			if (align_store(address, datasize / 8, data_d0))
++				return 1;
++		}
++	} else {
++		if (datasize == 128) {
++			if (align_load(address, 8, &data_d0) ||
++			    align_load(address + 8, 8, &data_d1))
++				return 1;
++		} else {
++			if (align_load(address, datasize / 8, &data_d0))
++				return 1;
++			data_d1 = 0;
++		}
++		set_vn_dt(t, 0, data_d0);
++		set_vn_dt(t, 1, data_d1);
++	}
++
++	if (wback) {
++		if (postindex)
++			address += offset;
++		if (n == 31)
++			regs->sp = address;
++		else
++			pt_regs_write_reg(regs, n, address);
++	}
++
++	return 0;
++}
++
++static int align_ldst(u32 insn, struct pt_regs *regs)
++{
++	const u32 op0 = FIELD_GET(GENMASK(31, 28), insn);
++	const u32 op1 = FIELD_GET(BIT(26), insn);
++	const u32 op2 = FIELD_GET(GENMASK(24, 23), insn);
++	const u32 op3 = FIELD_GET(GENMASK(21, 16), insn);
++	const u32 op4 = FIELD_GET(GENMASK(11, 10), insn);
++
++	if ((op0 & 0x3) == 0x2) {
++		/*
++		 * |------+-----+-----+-----+-----+-----------------------------------------|
++		 * | op0  | op1 | op2 | op3 | op4 | Decode group                            |
++		 * |------+-----+-----+-----+-----+-----------------------------------------|
++		 * | xx10 | -   |  00 | -   | -   | Load/store no-allocate pair (offset)    |
++		 * | xx10 | -   |  01 | -   | -   | Load/store register pair (post-indexed) |
++		 * | xx10 | -   |  10 | -   | -   | Load/store register pair (offset)       |
++		 * | xx10 | -   |  11 | -   | -   | Load/store register pair (pre-indexed)  |
++		 * |------+-----+-----+-----+-----+-----------------------------------------|
++		 */
++
++		if (op1 == 0) { /* V == 0 */
++			/* general */
++			return align_ldst_pair(insn, regs);
++		} else {
++			/* simdfp */
++			return align_ldst_pair_simdfp(insn, regs);
++		}
++	} else if ((op0 & 0x3) == 0x3 &&
++		   (((op2 & 0x2) == 0 && (op3 & 0x20) == 0 && op4 != 0x2) ||
++		    ((op2 & 0x2) == 0x2))) {
++		/*
++		 * |------+-----+-----+--------+-----+----------------------------------------------|
++		 * | op0  | op1 | op2 |    op3 | op4 | Decode group                                 |
++		 * |------+-----+-----+--------+-----+----------------------------------------------|
++		 * | xx11 | -   |  0x | 0xxxxx |  00 | Load/store register (unscaled immediate)     |
++		 * | xx11 | -   |  0x | 0xxxxx |  01 | Load/store register (immediate post-indexed) |
++		 * | xx11 | -   |  0x | 0xxxxx |  11 | Load/store register (immediate pre-indexed)  |
++		 * | xx11 | -   |  1x |      - |   - | Load/store register (unsigned immediate)     |
++		 * |------+-----+-----+--------+-----+----------------------------------------------|
++		 */
++
++		if (op1 == 0) {  /* V == 0 */
++			/* general */
++			return align_ldst_imm(insn, regs);
++		} else {
++			/* simdfp */
++			return align_ldst_imm_simdfp(insn, regs);
++		}
++	} else if ((op0 & 0x3) == 0x3 && (op2 & 0x2) == 0 &&
++		   (op3 & 0x20) == 0x20 && op4 == 0x2) {
++		/*
++		 * |------+-----+-----+--------+-----+---------------------------------------|
++		 * | op0  | op1 | op2 |    op3 | op4 |                                       |
++		 * |------+-----+-----+--------+-----+---------------------------------------|
++		 * | xx11 | -   |  0x | 1xxxxx |  10 | Load/store register (register offset) |
++		 * |------+-----+-----+--------+-----+---------------------------------------|
++		 */
++		if (op1 == 0) { /* V == 0 */
++			/* general */
++			return align_ldst_regoff(insn, regs);
++		} else {
++			/* simdfp */
++			return align_ldst_regoff_simdfp(insn, regs);
++		}
++	} else
++		return 1;
++}
++
++static int fixup_alignment(unsigned long addr, unsigned int esr,
++			   struct pt_regs *regs)
++{
++	u32 insn;
++	int res;
++
++	if (user_mode(regs)) {
++		__le32 insn_le;
++
++		if (!is_ttbr0_addr(addr))
++			return 1;
++
++		if (get_user(insn_le,
++			     (__le32 __user *)instruction_pointer(regs)))
++			return 1;
++		insn = le32_to_cpu(insn_le);
++	} else {
++		if (aarch64_insn_read((void *)instruction_pointer(regs), &insn))
++			return 1;
++	}
++
++	switch (aarch64_get_insn_class(insn)) {
++	case AARCH64_INSN_CLS_BR_SYS:
++		if (aarch64_insn_is_dc_zva(insn))
++			res = align_dc_zva(addr, regs);
++		else
++			res = 1;
++		break;
++	case AARCH64_INSN_CLS_LDST:
++		res = align_ldst(insn, regs);
++		break;
++	default:
++		res = 1;
++	}
++	if (!res) {
++		instruction_pointer_set(regs, instruction_pointer(regs) + 4);
++	}
++	return res;
++}
++
+ static int do_alignment_fault(unsigned long far, unsigned int esr,
+ 			      struct pt_regs *regs)
+ {
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++	if (!fixup_alignment(far, esr, regs))
++		return 0;
++#endif
+ 	do_bad_area(far, esr, regs);
+ 	return 0;
+ }
+-- 
+2.39.3
+

--- a/v5.15/0003-arm64-Add-alignment-faults-handler-for-Advanced-SIMD.patch
+++ b/v5.15/0003-arm64-Add-alignment-faults-handler-for-Advanced-SIMD.patch
@@ -1,0 +1,206 @@
+From 67ce6856f7577214ef331f80b171b244492ac4be Mon Sep 17 00:00:00 2001
+From: D Scott Phillips <scott@os.amperecomputing.com>
+Date: Thu, 3 Mar 2022 15:43:08 +0800
+Subject: [PATCH 03/10] arm64: Add alignment faults handler for Advanced SIMD
+ load/store single
+
+Signed-off-by: D Scott Phillips <scott@os.amperecomputing.com>
+---
+ arch/arm64/mm/fault.c | 160 +++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 159 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/mm/fault.c b/arch/arm64/mm/fault.c
+index d3998c789fcd..67f2cc8673df 100644
+--- a/arch/arm64/mm/fault.c
++++ b/arch/arm64/mm/fault.c
+@@ -789,7 +789,7 @@ static int align_dc_zva(unsigned long addr, struct pt_regs *regs)
+ 				return 1;
+ 		}
+ 	} else
+-		memset_io((void *)addr, 0, sz);
++		memset_io((void __iomem *)addr, 0, sz);
+ 	return 0;
+ }
+ 
+@@ -837,6 +837,44 @@ static void set_vn_dt(int n, int t, u64 val) {
+ 	}
+ }
+ 
++static u64 replicate64(u64 val, int bits)
++{
++	switch (bits) {
++	case 8:
++		val = (val << 8) | (val & 0xff);
++		fallthrough;
++	case 16:
++		val = (val << 16) | (val & 0xffff);
++		fallthrough;
++	case 32:
++		val = (val << 32) | (val & 0xffffffff);
++		break;
++	default:
++		break;
++	}
++	return val;
++}
++
++static u64 elem_get(u64 hi, u64 lo, int index, int esize)
++{
++	int shift = index * esize;
++	u64 mask = GENMASK(esize - 1, 0);
++	if (shift < 64)
++		return (lo >> shift) & mask;
++	else
++		return (hi >> (shift - 64)) & mask;
++}
++
++static void elem_set(u64 *hi, u64 *lo, int index, int esize, u64 val)
++{
++	int shift = index * esize;
++	u64 mask = GENMASK(esize - 1, 0);
++	if (shift < 64)
++		*lo = (*lo & ~(mask << shift)) | ((val & mask) << shift);
++	else
++		*hi = (*hi & ~(mask << (shift - 64))) | ((val & mask) << (shift - 64));
++}
++
+ static int align_ldst_pair(u32 insn, struct pt_regs *regs)
+ {
+ 	const u32 OPC = GENMASK(31, 30);
+@@ -1316,6 +1354,114 @@ static int align_ldst_imm_simdfp(u32 insn, struct pt_regs *regs)
+ 	return 0;
+ }
+ 
++static int align_ldst_vector_single(u32 insn, struct pt_regs *regs)
++{
++	const u32 Q_MASK = BIT(30);
++	const u32 L_MASK = BIT(22);
++	const u32 R_MASK = BIT(21);
++	const u32 OPCODE = GENMASK(15, 13);
++	const u32 S_MASK = BIT(12);
++	const u32 SIZE = GENMASK(11, 10);
++	u32 Q = FIELD_GET(Q_MASK, insn);
++	u32 L = FIELD_GET(L_MASK, insn);
++	u32 R = FIELD_GET(R_MASK, insn);
++	u32 opcode = FIELD_GET(OPCODE, insn);
++	u32 S = FIELD_GET(S_MASK, insn);
++	u32 size = FIELD_GET(SIZE, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int m = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RM, insn);
++	bool wback = !!(insn & BIT(23));
++	int init_scale = opcode >> 1;
++	int scale = init_scale;
++	int selem = (((opcode & 1) << 1) | R) + 1;
++	bool replicate = false;
++	int index;
++	int datasize;
++	int esize;
++	u64 address;
++	u64 offs;
++	u64 rval_d0, rval_d1;
++	u64 element;
++	int ebytes;
++	int s;
++	u64 data;
++	switch (scale) {
++	case 3:
++		if (!L || S)
++			return 1;
++		scale = size;
++		replicate = true;
++		break;
++	case 0:
++		index = (Q << 3) | (S << 2) | size;
++		break;
++	case 1:
++		if (size & 1)
++			return 1;
++		index = (Q << 2) | (S << 1) | (size >> 1);
++		break;
++	case 2:
++		if (size & 2)
++			return 1;
++		if (!(size & 1))
++			index = (Q << 1) | S;
++		else {
++			if (S)
++				return 1;
++			index = Q;
++			scale = 3;
++		}
++		break;
++	}
++	datasize = Q ? 128 : 64;
++	esize = 8 << scale;
++	ebytes = esize / 8;
++	address = regs_get_register(regs, n << 3);
++	offs = 0;
++	if (replicate) {
++		for (s = 0; s < selem; s++) {
++			if (align_load(address + offs, ebytes, &element))
++				return 1;
++			data = replicate64(element, esize);
++			set_vn_dt(t, 0, data);
++			if (datasize == 128)
++				set_vn_dt(t, 1, data);
++			else
++				set_vn_dt(t, 1, 0);
++			offs += ebytes;
++			t = (t + 1) & 31;
++		}
++	} else {
++		for (s = 0; s < selem; s++) {
++			rval_d0 = get_vn_dt(t, 0);
++			rval_d1 = get_vn_dt(t, 1);
++			if (L) {
++				if (align_load(address + offs, ebytes, &data))
++					return 1;
++				elem_set(&rval_d1, &rval_d0, index, esize, data);
++				set_vn_dt(t, 0, rval_d0);
++				set_vn_dt(t, 1, rval_d1);
++			} else {
++				data = elem_get(rval_d1, rval_d0, index, esize);
++				if (align_store(address + offs, ebytes, data))
++					return 1;
++			}
++			offs += ebytes;
++			t = (t + 1) & 31;
++		}
++	}
++	if (wback) {
++		if (m != 31)
++			offs = regs_get_register(regs, m << 3);
++		if (n == 31)
++			regs->sp = address + offs;
++		else
++			pt_regs_write_reg(regs, n, address + offs);
++	}
++	return 0;
++}
++
+ static int align_ldst(u32 insn, struct pt_regs *regs)
+ {
+ 	const u32 op0 = FIELD_GET(GENMASK(31, 28), insn);
+@@ -1380,6 +1526,18 @@ static int align_ldst(u32 insn, struct pt_regs *regs)
+ 			/* simdfp */
+ 			return align_ldst_regoff_simdfp(insn, regs);
+ 		}
++	} else if ((op0 & 0xb) == 0 && op1 == 1 &&
++		   ((op2 == 2 && ((op3 & 0x1f) == 0)) || op2 == 3)) {
++		/*
++		 * |------+-----+-----+--------+-----+-------------------------------------------|
++		 * | op0  | op1 | op2 |    op3 | op4 |                                           |
++		 * |------+-----+-----+--------+-----+-------------------------------------------|
++		 * | 0x00 |   1 |  10 | x00000 |   - | Advanced SIMD load/store single structure |
++		 * | 0x00 |   1 |  11 |      - |   - | Advanced SIMD load/store single structure |
++		 * |      |     |     |        |     |   (post-indexed)                          |
++		 * |------+-----+-----+--------+-----+-------------------------------------------|
++		 */
++		return align_ldst_vector_single(insn, regs);
+ 	} else
+ 		return 1;
+ }
+-- 
+2.39.3
+

--- a/v5.15/0004-arm64-remove-the-hardcode-about-PCI-address-checking.patch
+++ b/v5.15/0004-arm64-remove-the-hardcode-about-PCI-address-checking.patch
@@ -1,0 +1,159 @@
+From 248bfd479cbb2d28fe60ab7ec68416c474b4a7e8 Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Fri, 8 Apr 2022 20:43:33 +0000
+Subject: [PATCH 04/10] arm64: remove the hardcode about PCI address checking
+
+Copy name in find_next_iomem_res() for checking the PCI
+address.
+
+Remove the bool check for VM which does not has the ALTRA pci device.
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/include/asm/pgtable.h |  7 +++---
+ arch/arm64/mm/ioremap.c          | 13 +++-------
+ include/linux/pci.h              |  4 +++
+ kernel/resource.c                | 43 ++++++++++++++++++++++++++++++++
+ 4 files changed, 54 insertions(+), 13 deletions(-)
+
+diff --git a/arch/arm64/include/asm/pgtable.h b/arch/arm64/include/asm/pgtable.h
+index e3f3bbe34cfe..4a0145d5d095 100644
+--- a/arch/arm64/include/asm/pgtable.h
++++ b/arch/arm64/include/asm/pgtable.h
+@@ -521,6 +521,8 @@ static inline pmd_t pmd_mkdevmap(pmd_t pmd)
+ 
+ #ifdef CONFIG_ALTRA_ERRATUM_82288
+ extern bool have_altra_erratum_82288;
++extern bool range_is_pci(phys_addr_t, size_t);
++
+ #endif
+ 
+ static inline pte_t pte_mkspecial(pte_t pte)
+@@ -529,10 +531,7 @@ static inline pte_t pte_mkspecial(pte_t pte)
+ 	phys_addr_t phys = __pte_to_phys(pte);
+ 	pgprot_t prot = __pgprot(pte_val(pte) & ~PTE_ADDR_MASK);
+ 
+-	if (unlikely(have_altra_erratum_82288) &&
+-	    (phys < 0x80000000 ||
+-	     (phys >= 0x200000000000 && phys < 0x400000000000) ||
+-	     (phys >= 0x600000000000 && phys < 0x800000000000))) {
++	if (range_is_pci(phys, PAGE_SIZE)) {
+ 		pte = __pte(__phys_to_pte_val(phys) | pgprot_val(pgprot_device(prot)));
+ 	}
+ #endif
+diff --git a/arch/arm64/mm/ioremap.c b/arch/arm64/mm/ioremap.c
+index bdc34c4d7ff5..5cb8dc690167 100644
+--- a/arch/arm64/mm/ioremap.c
++++ b/arch/arm64/mm/ioremap.c
+@@ -13,6 +13,7 @@
+ #include <linux/mm.h>
+ #include <linux/vmalloc.h>
+ #include <linux/io.h>
++#include <linux/pci.h>
+ 
+ #include <asm/fixmap.h>
+ #include <asm/tlbflush.h>
+@@ -20,14 +21,6 @@
+ #ifdef CONFIG_ALTRA_ERRATUM_82288
+ bool have_altra_erratum_82288 __read_mostly;
+ EXPORT_SYMBOL(have_altra_erratum_82288);
+-
+-static bool is_altra_pci(phys_addr_t phys_addr, size_t size)
+-{
+-	phys_addr_t end = phys_addr + size;
+-	return (phys_addr < 0x80000000 ||
+-		(end > 0x200000000000 && phys_addr < 0x400000000000) ||
+-		(end > 0x600000000000 && phys_addr < 0x800000000000));
+-}
+ #endif
+ 
+ static void __iomem *__ioremap_caller(phys_addr_t phys_addr, size_t size,
+@@ -66,8 +59,10 @@ static void __iomem *__ioremap_caller(phys_addr_t phys_addr, size_t size,
+ 	area->phys_addr = phys_addr;
+ 
+ #ifdef CONFIG_ALTRA_ERRATUM_82288
+-	if (unlikely(have_altra_erratum_82288 && is_altra_pci(phys_addr, size)))
++	if ((pgprot_val(prot) != pgprot_val(pgprot_device(prot))) &&
++			range_is_pci(phys_addr, size)) {
+ 		prot = pgprot_device(prot);
++	}
+ #endif
+ 
+ 	err = ioremap_page_range(addr, addr + size, phys_addr, prot);
+diff --git a/include/linux/pci.h b/include/linux/pci.h
+index 9d6e75222868..c5b817be4774 100644
+--- a/include/linux/pci.h
++++ b/include/linux/pci.h
+@@ -2478,4 +2478,8 @@ void pci_uevent_ers(struct pci_dev *pdev, enum  pci_ers_result err_type);
+ 	WARN_ONCE(condition, "%s %s: " fmt, \
+ 		  dev_driver_string(&(pdev)->dev), pci_name(pdev), ##arg)
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++extern bool range_is_pci(phys_addr_t phys_addr, size_t size);
++#endif
++
+ #endif /* LINUX_PCI_H */
+diff --git a/kernel/resource.c b/kernel/resource.c
+index 20e10e48f052..5bde7d2d3325 100644
+--- a/kernel/resource.c
++++ b/kernel/resource.c
+@@ -352,6 +352,7 @@ static int find_next_iomem_res(resource_size_t start, resource_size_t end,
+ 			.flags = p->flags,
+ 			.desc = p->desc,
+ 			.parent = p->parent,
++			.name = p->name,
+ 		};
+ 	}
+ 
+@@ -477,6 +478,48 @@ int __weak page_is_ram(unsigned long pfn)
+ }
+ EXPORT_SYMBOL_GPL(page_is_ram);
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++/* Return 0 on success, else return 1 */
++static int pci_addr_check(struct resource *r, void *p)
++{
++	if (!r->name)
++		return 1;
++
++	if (strlen(r->name) <= 2)
++		return 1;
++
++	if (memcmp(r->name, "PCI", 3))
++		return 1;
++
++	/* Success */
++	return 0;
++}
++
++bool range_is_pci(phys_addr_t phys_addr, size_t size)
++{
++	u64 start, end;
++	int ret;
++
++	start = phys_addr;
++	end = phys_addr + size;
++
++	/* Check the 32bit */
++	ret = walk_iomem_res_desc(IORES_DESC_NONE, IORESOURCE_MEM,
++			start, end, NULL, pci_addr_check);
++	if (!ret)
++		return true;
++
++	/* Check the 64bit */
++	ret = walk_iomem_res_desc(IORES_DESC_NONE, IORESOURCE_MEM_64,
++			start, end, NULL, pci_addr_check);
++	if (!ret)
++		return true;
++
++	return false;
++}
++EXPORT_SYMBOL_GPL(range_is_pci);
++#endif
++
+ static int __region_intersects(resource_size_t start, size_t size,
+ 			unsigned long flags, unsigned long desc)
+ {
+-- 
+2.39.3
+

--- a/v5.15/0005-arm64-Add-new-code-for-unaligned-pcie-access.patch
+++ b/v5.15/0005-arm64-Add-new-code-for-unaligned-pcie-access.patch
@@ -1,0 +1,313 @@
+From 10ccea1f0191858536580078116289b169f3512a Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Tue, 12 Apr 2022 12:09:54 +0000
+Subject: [PATCH 05/10] arm64: Add new code for unaligned pcie access
+
+Add a new function align_ldst_new to handle the rest instructions
+if align_ldst() fails.
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/mm/fault.c               |  18 ++-
+ arch/arm64/mm/pcie_unalign_access.c | 235 ++++++++++++++++++++++++++++
+ 2 files changed, 252 insertions(+), 1 deletion(-)
+ create mode 100644 arch/arm64/mm/pcie_unalign_access.c
+
+diff --git a/arch/arm64/mm/fault.c b/arch/arm64/mm/fault.c
+index 67f2cc8673df..95c2eb6c6476 100644
+--- a/arch/arm64/mm/fault.c
++++ b/arch/arm64/mm/fault.c
+@@ -1542,11 +1542,15 @@ static int align_ldst(u32 insn, struct pt_regs *regs)
+ 		return 1;
+ }
+ 
++#include "pcie_unalign_access.c"
++
+ static int fixup_alignment(unsigned long addr, unsigned int esr,
+ 			   struct pt_regs *regs)
+ {
+ 	u32 insn;
+ 	int res;
++	struct pt_regs t = *regs;
++	int type;
+ 
+ 	if (user_mode(regs)) {
+ 		__le32 insn_le;
+@@ -1563,7 +1567,10 @@ static int fixup_alignment(unsigned long addr, unsigned int esr,
+ 			return 1;
+ 	}
+ 
+-	switch (aarch64_get_insn_class(insn)) {
++	pr_debug("start to handle insn:%x\n", insn);
++
++	type = aarch64_get_insn_class(insn);
++	switch (type) {
+ 	case AARCH64_INSN_CLS_BR_SYS:
+ 		if (aarch64_insn_is_dc_zva(insn))
+ 			res = align_dc_zva(addr, regs);
+@@ -1572,12 +1579,21 @@ static int fixup_alignment(unsigned long addr, unsigned int esr,
+ 		break;
+ 	case AARCH64_INSN_CLS_LDST:
+ 		res = align_ldst(insn, regs);
++		if (res) {
++			/* Try it again, copy back if we succeed */
++			res = align_ldst_new(insn, &t);
++			if (!res)
++				*regs = t;
++		}
+ 		break;
+ 	default:
+ 		res = 1;
+ 	}
+ 	if (!res) {
+ 		instruction_pointer_set(regs, instruction_pointer(regs) + 4);
++	} else {
++		pr_err("cannot handle insn:%x, type:%d\n", insn, type);
++		dump_stack();
+ 	}
+ 	return res;
+ }
+diff --git a/arch/arm64/mm/pcie_unalign_access.c b/arch/arm64/mm/pcie_unalign_access.c
+new file mode 100644
+index 000000000000..f7c948985296
+--- /dev/null
++++ b/arch/arm64/mm/pcie_unalign_access.c
+@@ -0,0 +1,235 @@
++struct ldst_filter {
++	u32 mask;
++	u32 arm_code;
++	char *name;
++	int (*handler)(struct ldst_filter *, u32, struct pt_regs*);
++};
++
++static int ldst_default(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	pr_alert("instruction :%x(%s) is not implemented.\n", insn, f->name);
++	return 1;
++}
++
++/*
++ * |------+-----+-----+-----+-----+-----------------------------------------|
++ * | op0  | op1 | op2 | op3 | op4 | Decode group                            |
++ * |------+-----+-----+-----+-----+-----------------------------------------|
++ * | xx10 | -   |  00 | -   | -   | Load/store no-allocate pair (offset)    |
++ * | xx10 | -   |  01 | -   | -   | Load/store register pair (post-indexed) |
++ * | xx10 | -   |  10 | -   | -   | Load/store register pair (offset)       |
++ * | xx10 | -   |  11 | -   | -   | Load/store register pair (pre-indexed)  |
++ * |------+-----+-----+-----+-----+-----------------------------------------|
++ */
++static int ldst_type_pair(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	/* The bit 26 is used for SIMD only, please see the spec */
++	if (insn & BIT(26))
++		return align_ldst_pair_simdfp(insn, regs);
++	else
++		return align_ldst_pair(insn, regs);
++}
++
++/*
++ * |------+-----+-----+--------+-----+----------------------------------------------|
++ * | op0  | op1 | op2 |    op3 | op4 | Decode group                                 |
++ * |------+-----+-----+--------+-----+----------------------------------------------|
++ * | xx11 | -   |  0x | 0xxxxx |  00 | Load/store register (unscaled immediate)     |
++ * | xx11 | -   |  0x | 0xxxxx |  01 | Load/store register (immediate post-indexed) |
++ * | xx11 | -   |  0x | 0xxxxx |  11 | Load/store register (immediate pre-indexed)  |
++ * | xx11 | -   |  1x |      - |   - | Load/store register (unsigned immediate)     |
++ * |------+-----+-----+--------+-----+----------------------------------------------|
++ */
++static int ldst_type_imm(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	/* The bit 26 is used for SIMD only, please see the spec */
++	if (insn & BIT(26))
++		return align_ldst_imm_simdfp(insn, regs);
++	else
++		return align_ldst_imm(insn, regs);
++}
++
++/*
++ * |------+-----+-----+--------+-----+---------------------------------------|
++ * | op0  | op1 | op2 |    op3 | op4 |                                       |
++ * |------+-----+-----+--------+-----+---------------------------------------|
++ * | xx11 | -   |  0x | 1xxxxx |  10 | Load/store register (register offset) |
++ * |------+-----+-----+--------+-----+---------------------------------------|
++ */
++static int ldst_type_regoff(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	/* The bit 26 is used for SIMD only, please see the spec */
++	if (insn & BIT(26))
++		return align_ldst_regoff_simdfp(insn, regs);
++	else
++		return align_ldst_regoff(insn, regs);
++}
++
++/*
++ * |------+-----+-----+--------+-----+-------------------------------------------|
++ * | op0  | op1 | op2 |    op3 | op4 |                                           |
++ * |------+-----+-----+--------+-----+-------------------------------------------|
++ * | 0x00 |   1 |  10 | x00000 |   - | Advanced SIMD load/store single structure |
++ * | 0x00 |   1 |  11 |      - |   - | Advanced SIMD load/store single structure |
++ * |      |     |     |        |     |   (post-indexed)                          |
++ * |------+-----+-----+--------+-----+-------------------------------------------|
++ */
++static int ldst_type_vector_single(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	return align_ldst_vector_single(insn, regs);
++}
++
++/* Please see the C4.1.66 */
++static const struct ldst_filter ldst_filters[] = {
++	{
++		.mask		= BIT(31) | GENMASK(29, 28) | BIT(26)
++					| GENMASK(24, 23) | BIT(21),
++		.arm_code	= BIT(21),
++		.name		= "Compare and swap pair",
++		.handler	= ldst_default,
++	}, {
++		.mask		= BIT(31) | GENMASK(29, 28) | BIT(26)
++					| GENMASK(24, 23) | GENMASK(21, 16),
++		.arm_code	= BIT(26),
++		.name		= "Advanced SIMD load/store multiple structures",
++		.handler	= ldst_default,
++	}, {
++		.mask		= BIT(31) | GENMASK(29, 28) | BIT(26)
++					| GENMASK(24, 23) | BIT(21),
++		.arm_code	= BIT(26) | BIT(23),
++		.name		= "Advanced SIMD load/store multiple structures(post-indexed)",
++		.handler	= ldst_default,
++	}, {
++		.mask		= BIT(31) | GENMASK(29, 28) | BIT(26)
++					| GENMASK(24, 23) | GENMASK(20, 16),
++		.arm_code	= BIT(26) | BIT(24),
++		.name		= "Advanced SIMD load/store single structures",
++		.handler	= ldst_type_vector_single,
++	}, {
++		.mask		= BIT(31) | GENMASK(29, 28) | BIT(26) | GENMASK(24, 23),
++		.arm_code	= BIT(26) | BIT(24) | BIT(23),
++		.name		= "Advanced SIMD load/store single structures(post-indexed)",
++		.handler	= ldst_type_vector_single,
++	}, {
++		.mask		= GENMASK(31, 28) | BIT(26) | BIT(24) | BIT(21),
++		.arm_code	= BIT(31) | BIT(30) | BIT(28) | BIT(24) | BIT(21),
++		.name		= "Load/store memory tags",
++		.handler	= ldst_default,
++	}, {
++		.mask		= BIT(31) | GENMASK(29, 28) | BIT(26)
++					| GENMASK(24, 23) | BIT(21),
++		.arm_code	= BIT(31) | BIT(21),
++		.name		= "Load/store exclusive pair",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(26) | GENMASK(24, 23) | BIT(21),
++		.arm_code	= 0,
++		.name		= "Load/store exclusive register",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(26) | GENMASK(24, 23) | BIT(21),
++		.arm_code	= BIT(23),
++		.name		= "Load/store ordered",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(26) | GENMASK(24, 23) | BIT(21),
++		.arm_code	= BIT(23) | BIT(21),
++		.name		= "Compare and swap",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(26) | BIT(24) | BIT(21) |
++					GENMASK(11, 10),
++		.arm_code	= BIT(28) | BIT(24),
++		.name		= "LDAPR/STLR(unscaled immediate)",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24),
++		.arm_code	= BIT(28),
++		.name		= "Load register(literal)",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(28) | BIT(10),
++		.name		= "Memory Copy and Memory Set",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | GENMASK(24, 23),
++		.arm_code	= BIT(29),
++		.name		= "Load/store no-allocate pair(offset)",
++		.handler	= ldst_type_pair,
++	}, {
++		.mask		= GENMASK(29, 28) | GENMASK(24, 23),
++		.arm_code	= BIT(29) | BIT(23),
++		.name		= "Load/store register pair(post-indexed)",
++		.handler	= ldst_type_pair,
++	}, {
++		.mask		= GENMASK(29, 28) | GENMASK(24, 23),
++		.arm_code	= BIT(29) | BIT(24),
++		.name		= "Load/store register pair(offset)",
++		.handler	= ldst_type_pair,
++	}, {
++		.mask		= GENMASK(29, 28) | GENMASK(24, 23),
++		.arm_code	= BIT(29) | BIT(24) | BIT(23),
++		.name		= "Load/store register pair(pre-indexed)",
++		.handler	= ldst_type_pair,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(29) | BIT(28),
++		.name		= "Load/store register (unscaled immediate)",
++		.handler	= ldst_type_imm,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(29) | BIT(28) | BIT(10),
++		.name		= "Load/store register (immediate post-indexed)",
++		.handler	= ldst_type_imm,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(29) | BIT(28) | BIT(11),
++		.name		= "Load/store register (unprivileged)",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(29) | BIT(28) | BIT(11) | BIT(10),
++		.name		= "Load/store register (immediate pre-indexed)",
++		.handler	= ldst_type_imm,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(29) | BIT(28) | BIT(21),
++		.name		= "Atomic memory operation",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(29) | BIT(28) | BIT(21) | BIT(11),
++		.name		= "Load/store register (register offset)",
++		.handler	= ldst_type_regoff,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | BIT(10),
++		.arm_code	= BIT(29) | BIT(28) | BIT(21) | BIT(10),
++		.name		= "Load/store register (pac)",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24),
++		.arm_code	= BIT(29) | BIT(28) | BIT(24),
++		.name		= "Load/store register (unsigned immediate)",
++		.handler	= ldst_type_imm,
++	},
++};
++
++/* Return 0 on success, return 1 on failure. */
++static int align_ldst_new(u32 insn, struct pt_regs *regs)
++{
++	int i;
++	struct ldst_filter *f;
++
++	for (i = 0; i < ARRAY_SIZE(ldst_filters); i++) {
++		f = (struct ldst_filter *)&ldst_filters[i];
++
++		/* Find the correct hander */
++		if ((f->mask & insn) == f->arm_code) {
++			pr_debug("insn:%x, (%s)\n", insn, f->name);
++			return f->handler(f, insn, regs);
++		}
++	}
++
++	return 1;
++}
+-- 
+2.39.3
+

--- a/v5.15/0006-arm64-fix-the-error-for-instruction-b9400000.patch
+++ b/v5.15/0006-arm64-fix-the-error-for-instruction-b9400000.patch
@@ -1,0 +1,128 @@
+From 8d674d6cbe9c7a89159449e71f77df3403b180e5 Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Sun, 17 Apr 2022 14:20:09 +0000
+Subject: [PATCH 06/10] arm64: fix the error for instruction :b9400000
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/mm/pcie_unalign_access.c | 97 ++++++++++++++++++++++++++++-
+ 1 file changed, 96 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/mm/pcie_unalign_access.c b/arch/arm64/mm/pcie_unalign_access.c
+index f7c948985296..6dfcd4929a77 100644
+--- a/arch/arm64/mm/pcie_unalign_access.c
++++ b/arch/arm64/mm/pcie_unalign_access.c
+@@ -30,6 +30,101 @@ static int ldst_type_pair(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
+ 		return align_ldst_pair(insn, regs);
+ }
+ 
++static int align_ldst_imm_new(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	bool wback = !(insn & BIT(24)) && !!(insn & BIT(10));
++	bool postindex = wback && !(insn & BIT(11));
++	int scale = size;
++	u64 offset;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	bool is_store;
++	bool is_signed;
++	int regsize;
++	int datasize;
++	u64 address;
++	u64 data;
++
++	if (!(insn & BIT(24))) {
++		u64 uoffset =
++			aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++		offset = sign_extend64(uoffset, 8);
++	} else {
++		offset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_12, insn);
++		offset <<= scale;
++	}
++
++	if ((opc & 0x2) == 0) {
++		/* store or zero-extending load */
++		is_store = !(opc & 0x1);
++		regsize = size == 0x3 ? 64 : 32;
++		is_signed = false;
++	} else {
++		if (size == 0x3) {
++			if (FIELD_GET(GENMASK(11, 10), insn) == 0 && (opc & 0x1) == 0) {
++				/* prefetch */
++				return 0;
++			} else {
++				/* undefined */
++				return 1;
++			}
++		} else {
++			/* sign-extending load */
++			is_store = false;
++			if (size == 0x2 && (opc & 0x1) == 0x1) {
++				/* undefined */
++				return 1;
++			}
++			regsize = (opc & 0x1) == 0x1 ? 32 : 64;
++			is_signed = true;
++		}
++	}
++
++	datasize = 8 << scale;
++
++	if (wback && n == t && n != 31)
++		return 1;
++
++	address = regs_get_register(regs, n << 3);
++
++	if (!postindex)
++		address += offset;
++	printk("{%s] addr:%llx, offset:%llx\n", __func__, address, offset);
++
++	if (is_store) {
++		data = pt_regs_read_reg(regs, t);
++		if (align_store(address, datasize / 8, data))
++			return 1;
++	} else {
++		if (align_load(address, datasize / 8, &data))
++			return 1;
++		if (is_signed) {
++			if (regsize == 32)
++				data = sign_extend32(data, datasize - 1);
++			else
++				data = sign_extend64(data, datasize - 1);
++		}
++		pt_regs_write_reg(regs, t, data);
++	}
++
++	if (wback) {
++		if (postindex)
++			address += offset;
++		if (n == 31)
++			regs->sp = address;
++		else
++			pt_regs_write_reg(regs, n, address);
++	}
++
++	return 0;
++}
++
+ /*
+  * |------+-----+-----+--------+-----+----------------------------------------------|
+  * | op0  | op1 | op2 |    op3 | op4 | Decode group                                 |
+@@ -46,7 +141,7 @@ static int ldst_type_imm(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
+ 	if (insn & BIT(26))
+ 		return align_ldst_imm_simdfp(insn, regs);
+ 	else
+-		return align_ldst_imm(insn, regs);
++		return align_ldst_imm_new(insn, regs);
+ }
+ 
+ /*
+-- 
+2.39.3
+

--- a/v5.15/0007-arm64-add-unprivileged-instruction-support.patch
+++ b/v5.15/0007-arm64-add-unprivileged-instruction-support.patch
@@ -1,0 +1,335 @@
+From fa46ca92f1342b2a96a63485baf39d4fbbc25784 Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Mon, 9 May 2022 11:20:06 +0000
+Subject: [PATCH 07/10] arm64: add unprivileged instruction support
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/mm/pcie_unalign_access.c | 304 +++++++++++++++++++++++++++-
+ 1 file changed, 303 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/mm/pcie_unalign_access.c b/arch/arm64/mm/pcie_unalign_access.c
+index 6dfcd4929a77..835bbdee8882 100644
+--- a/arch/arm64/mm/pcie_unalign_access.c
++++ b/arch/arm64/mm/pcie_unalign_access.c
+@@ -174,6 +174,308 @@ static int ldst_type_vector_single(struct ldst_filter *f, u32 insn, struct pt_re
+ 	return align_ldst_vector_single(insn, regs);
+ }
+ 
++static int ldst_unpri_sttrb(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	data = pt_regs_read_reg(regs, t);
++
++	/* 3) store it now */
++	return align_store(address, 1, data);
++}
++
++static int ldst_unpri_ldtrb(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data = 0;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	align_load(address, 1, &data);
++	data = sign_extend64(data, 64 - 1);
++
++	/* 3) store it now */
++	pt_regs_write_reg(regs, t, data);
++	return 0;
++}
++
++static int ldst_unpri_ldtrsb_64(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data = 0;
++	int regsize = 64;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	align_load(address, 1, &data);
++
++	/* 64bit or 32 bit? check it with opc[0] */
++	if (insn & BIT(22))
++		regsize = 32;
++	data = sign_extend32(data, regsize - 1);
++
++	/* 3) store it now */
++	pt_regs_write_reg(regs, t, data);
++	return 0;
++}
++
++static int ldst_unpri_sttrh(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	data = pt_regs_read_reg(regs, t);
++
++	/* 3) store it now */
++	return align_store(address, 2, data);
++}
++
++static int ldst_unpri_ldtrh(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data = 0;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	align_load(address, 2, &data);
++	data = sign_extend64(data, 64 - 1);
++
++	/* 3) store it now */
++	pt_regs_write_reg(regs, t, data);
++	return 0;
++}
++
++static int ldst_unpri_ldtrsh(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data = 0;
++	int regsize = 64;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	align_load(address, 2, &data);
++
++	/* 64bit or 32 bit? check it with opc[0] */
++	if (insn & BIT(22))
++		regsize = 32;
++	data = sign_extend32(data, regsize - 1);
++
++	/* 3) store it now */
++	pt_regs_write_reg(regs, t, data);
++	return 0;
++}
++
++static int ldst_unpri_sttr(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data;
++	int scale;
++	int datasize;
++	const u32 SIZE = GENMASK(31, 30);
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	data = pt_regs_read_reg(regs, t);
++
++	/* 3) store it now */
++	scale = FIELD_GET(SIZE, insn);
++	datasize = 8 << scale;
++	return align_store(address, datasize / 8, data);
++}
++
++/* 0xf8400946 */
++static int ldst_unpri_ldtr(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data = 0;
++	int regsize = 64;
++	const u32 SIZE = GENMASK(31, 30);
++	int scale = FIELD_GET(SIZE, insn);
++	int datasize = 8 << scale;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	align_load(address, datasize / 8, &data);
++
++	/* 64bit or 32 bit? */
++	if (scale != 3)
++		regsize = 32;
++
++	/* 3) store it now */
++	pt_regs_write_reg(regs, t, data);
++	return 0;
++}
++
++static int ldst_unpri_ldtrsw(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data = 0;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	align_load(address, 4, &data);
++	data = sign_extend32(data, 64 - 1);
++
++	/* 3) store it now */
++	pt_regs_write_reg(regs, t, data);
++	return 0;
++}
++#define REG_UNPRI_MASK (BIT(31)| BIT(31) | BIT(26) | BIT(22) | BIT(23))
++static const struct ldst_filter ldst_reg_unpri[] = {
++	{
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= 0,
++		.name		= "STTRB",
++		.handler	= ldst_unpri_sttrb,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(22),
++		.name		= "LDTRB",
++		.handler	= ldst_unpri_ldtrb,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(23),
++		.name		= "LDTRSB - 64bit variant",
++		.handler	= ldst_unpri_ldtrsb_64,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(23) | BIT(22),
++		.name		= "LDTRSB - 32bit variant",
++		.handler	= ldst_unpri_ldtrsb_64,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(30),
++		.name		= "STTRH",
++		.handler	= ldst_unpri_sttrh,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(30) | BIT(22),
++		.name		= "LDTRH",
++		.handler	= ldst_unpri_ldtrh,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(30) | BIT(23),
++		.name		= "LDTRSH - 64bit variant",
++		.handler	= ldst_unpri_ldtrsh,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(30) | BIT(23) | BIT(22),
++		.name		= "LDTRSH - 32bit variant",
++		.handler	= ldst_unpri_ldtrsh,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(31),
++		.name		= "STTR - 32bit variant",
++		.handler	= ldst_unpri_sttr,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(31),
++		.name		= "LDTR - 32bit variant",
++		.handler	= ldst_unpri_ldtr,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(31) | BIT(23),
++		.name		= "LDTRSW",
++		.handler	= ldst_unpri_ldtrsw,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(31) | BIT(30),
++		.name		= "STTR - 64bit variant",
++		.handler	= ldst_unpri_sttr,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(31) | BIT(30) | BIT(22),
++		.name		= "LDTR - 64bit variant",
++		.handler	= ldst_unpri_ldtr,
++	},
++};
++
++/* Return 0 on success, return 1 on failure. */
++static int ldst_reg_unprivileged(struct ldst_filter *of, u32 insn, struct pt_regs *regs)
++{
++	int i;
++	struct ldst_filter *f;
++
++	for (i = 0; i < ARRAY_SIZE(ldst_reg_unpri); i++) {
++		f = (struct ldst_filter *)&ldst_reg_unpri[i];
++
++		/* Find the correct hander */
++		if ((f->mask & insn) == f->arm_code) {
++			pr_debug("insn:%x, (%s)\n", insn, f->name);
++			return f->handler(f, insn, regs);
++		}
++	}
++	return 1;
++}
++
+ /* Please see the C4.1.66 */
+ static const struct ldst_filter ldst_filters[] = {
+ 	{
+@@ -281,7 +583,7 @@ static const struct ldst_filter ldst_filters[] = {
+ 		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
+ 		.arm_code	= BIT(29) | BIT(28) | BIT(11),
+ 		.name		= "Load/store register (unprivileged)",
+-		.handler	= ldst_default,
++		.handler	= ldst_reg_unprivileged,
+ 	}, {
+ 		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
+ 		.arm_code	= BIT(29) | BIT(28) | BIT(11) | BIT(10),
+-- 
+2.39.3
+

--- a/v5.15/0008-arm64-pcie-wc-print-out-the-error-log.patch
+++ b/v5.15/0008-arm64-pcie-wc-print-out-the-error-log.patch
@@ -1,0 +1,31 @@
+From 63281e5bd3e75c359a769362cdf376da283d2420 Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Tue, 4 Jul 2023 14:15:44 +0800
+Subject: [PATCH 08/10] arm64: pcie-wc: print out the error log
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/mm/pcie_unalign_access.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm64/mm/pcie_unalign_access.c b/arch/arm64/mm/pcie_unalign_access.c
+index 835bbdee8882..52475f910154 100644
+--- a/arch/arm64/mm/pcie_unalign_access.c
++++ b/arch/arm64/mm/pcie_unalign_access.c
+@@ -623,8 +623,11 @@ static int align_ldst_new(u32 insn, struct pt_regs *regs)
+ 
+ 		/* Find the correct hander */
+ 		if ((f->mask & insn) == f->arm_code) {
+-			pr_debug("insn:%x, (%s)\n", insn, f->name);
+-			return f->handler(f, insn, regs);
++			int ret = f->handler(f, insn, regs);
++
++			if (ret)
++				pr_info("Failed in handling insn:%x, (%s)\n", insn, f->name);
++			return ret;
+ 		}
+ 	}
+ 
+-- 
+2.39.3
+

--- a/v5.15/0009-pcie-wc-add-support-for-fc2c6b41.patch
+++ b/v5.15/0009-pcie-wc-add-support-for-fc2c6b41.patch
@@ -1,0 +1,119 @@
+From e800029d0b0a66336b0c54937f494cfded032326 Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Wed, 5 Jul 2023 09:30:43 +0800
+Subject: [PATCH 09/10] pcie-wc: add support for fc2c6b41
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/mm/pcie_unalign_access.c | 81 ++++++++++++++++++++++++++++-
+ 1 file changed, 80 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/mm/pcie_unalign_access.c b/arch/arm64/mm/pcie_unalign_access.c
+index 52475f910154..639c6a48ddee 100644
+--- a/arch/arm64/mm/pcie_unalign_access.c
++++ b/arch/arm64/mm/pcie_unalign_access.c
+@@ -144,6 +144,84 @@ static int ldst_type_imm(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
+ 		return align_ldst_imm_new(insn, regs);
+ }
+ 
++/* handle for fc2c6b41 */
++static int align_ldst_regoff_simdfp_new(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++	const u32 OPTION = GENMASK(15, 13);
++	const u32 S = BIT(12);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	u32 option = FIELD_GET(OPTION, insn);
++	u32 s = FIELD_GET(S, insn);
++	int scale = (opc & 0x2) << 1 | size;
++	int extend_len = (option & 0x1) ? 64 : 32;
++	bool extend_unsigned = !(option & 0x4);
++	int shift = s ? scale : 0;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int m = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RM, insn);
++	bool is_store = !(opc & BIT(0));
++	int datasize;
++	u64 offset;
++	u64 address;
++	u64 data_d0, data_d1;
++
++	/*
++	if ((opc & 0x2) == 0)
++		return 1;
++	*/
++
++	datasize = 8 << scale;
++
++	if (n == t && n != 31)
++		return 1;
++
++	offset = pt_regs_read_reg(regs, m);
++	if (extend_len == 32) {
++		offset &= (u32)~0;
++		if (!extend_unsigned)
++			sign_extend64(offset, 31);
++	}
++	offset <<= shift;
++
++	address = regs_get_register(regs, n << 3) + offset;
++
++	if (is_store) {
++		data_d0 = get_vn_dt(t, 0);
++		if (datasize == 128) {
++			data_d1 = get_vn_dt(t, 1);
++			if (align_store(address, 8, data_d0) ||
++			    align_store(address + 8, 8, data_d1))
++				return 1;
++		} else if (datasize == 64) {
++			/* fc2c6b41 should come here. */
++			if (align_store(address, 8, data_d0))
++				return 1;
++		} else {
++			if (align_store(address, datasize / 8, data_d0))
++				return 1;
++		}
++	} else {
++		if (datasize == 128) {
++			if (align_load(address, 8, &data_d0) ||
++			    align_load(address + 8, 8, &data_d1))
++				return 1;
++		} else {
++			if (align_load(address, datasize / 8, &data_d0))
++				return 1;
++			data_d1 = 0;
++		}
++		set_vn_dt(t, 0, data_d0);
++		set_vn_dt(t, 1, data_d1);
++	}
++
++	return 0;
++}
++
+ /*
+  * |------+-----+-----+--------+-----+---------------------------------------|
+  * | op0  | op1 | op2 |    op3 | op4 |                                       |
+@@ -155,7 +233,7 @@ static int ldst_type_regoff(struct ldst_filter *f, u32 insn, struct pt_regs *reg
+ {
+ 	/* The bit 26 is used for SIMD only, please see the spec */
+ 	if (insn & BIT(26))
+-		return align_ldst_regoff_simdfp(insn, regs);
++		return align_ldst_regoff_simdfp_new(insn, regs);
+ 	else
+ 		return align_ldst_regoff(insn, regs);
+ }
+@@ -625,6 +703,7 @@ static int align_ldst_new(u32 insn, struct pt_regs *regs)
+ 		if ((f->mask & insn) == f->arm_code) {
+ 			int ret = f->handler(f, insn, regs);
+ 
++			pr_debug("handling insn:%x, (%s)\n", insn, f->name);
+ 			if (ret)
+ 				pr_info("Failed in handling insn:%x, (%s)\n", insn, f->name);
+ 			return ret;
+-- 
+2.39.3
+

--- a/v5.15/0010-arm64-pcie-wc-fix-the-typo-for-f8400865.patch
+++ b/v5.15/0010-arm64-pcie-wc-fix-the-typo-for-f8400865.patch
@@ -1,0 +1,26 @@
+From 3bc42fd563874c0415d7bf4f2521151a725ab1ae Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Fri, 28 Jul 2023 15:37:35 +0800
+Subject: [PATCH 10/10] arm64: pcie-wc: fix the typo for f8400865
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/mm/pcie_unalign_access.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/mm/pcie_unalign_access.c b/arch/arm64/mm/pcie_unalign_access.c
+index 639c6a48ddee..66826dfe4e9c 100644
+--- a/arch/arm64/mm/pcie_unalign_access.c
++++ b/arch/arm64/mm/pcie_unalign_access.c
+@@ -466,7 +466,7 @@ static int ldst_unpri_ldtrsw(struct ldst_filter *f, u32 insn, struct pt_regs *re
+ 	pt_regs_write_reg(regs, t, data);
+ 	return 0;
+ }
+-#define REG_UNPRI_MASK (BIT(31)| BIT(31) | BIT(26) | BIT(22) | BIT(23))
++#define REG_UNPRI_MASK (BIT(31)| BIT(30) | BIT(26) | BIT(22) | BIT(23))
+ static const struct ldst_filter ldst_reg_unpri[] = {
+ 	{
+ 		.mask		= REG_UNPRI_MASK,
+-- 
+2.39.3
+

--- a/v5.15/0011-Fix-ttbr0-emulation-of-dc-zva.patch
+++ b/v5.15/0011-Fix-ttbr0-emulation-of-dc-zva.patch
@@ -1,0 +1,28 @@
+From 9b84f0462ed3294c69a7de87c319d7909b7c9295 Mon Sep 17 00:00:00 2001
+From: D Scott Phillips <scott@os.amperecomputing.com>
+Date: Thu, 20 Mar 2025 07:45:49 -0700
+Subject: [PATCH 1/1] Fix ttbr0 emulation of dc zva
+
+The loop to emulate dc zva in the ttbr0 range was mistakenly not
+updating the address, so not actually clearing all the data in the dc
+zva access, but only the first byte.
+---
+ arch/arm64/mm/fault.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/mm/fault.c b/arch/arm64/mm/fault.c
+index 5e5e0926cb8f..e24bf5d06735 100644
+--- a/arch/arm64/mm/fault.c
++++ b/arch/arm64/mm/fault.c
+@@ -785,7 +785,7 @@ static int align_dc_zva(unsigned long addr, struct pt_regs *regs)
+ 	addr &= ~(sz - 1);
+ 	if (is_ttbr0_addr(addr)) {
+ 		for (; sz; sz--) {
+-			if (align_store(addr, 1, 0))
++			if (align_store(addr++, 1, 0))
+ 				return 1;
+ 		}
+ 	} else
+-- 
+2.27.0
+

--- a/v5.15/0012-Fix-load-in-align_ldst_regoff.patch
+++ b/v5.15/0012-Fix-load-in-align_ldst_regoff.patch
@@ -1,0 +1,25 @@
+From 04c3222aba6f40ea2bb804f0cf9adf85327520f5 Mon Sep 17 00:00:00 2001
+From: davidz-ampere <>
+Date: Mon, 24 Mar 2025 22:52:47 -0400
+Subject: [PATCH 1/1] Fix load in align_ldst_regoff
+
+Data is not written back to the register and will cause data mismatch.
+---
+ arch/arm64/mm/fault.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/mm/fault.c b/arch/arm64/mm/fault.c
+index e24bf5d06735..4edb65fe0396 100644
+--- a/arch/arm64/mm/fault.c
++++ b/arch/arm64/mm/fault.c
+@@ -1109,6 +1109,7 @@ static int align_ldst_regoff(u32 insn, struct pt_regs *regs)
+ 			else
+ 				data = sign_extend64(data, datasize - 1);
+ 		}
++		pt_regs_write_reg(regs, t, data);
+ 	}
+ 
+ 	return 0;
+-- 
+2.27.0
+

--- a/v5.4/0001-arm64-Work-around-Ampere-Altra-erratum-82288-PCIE_65.patch
+++ b/v5.4/0001-arm64-Work-around-Ampere-Altra-erratum-82288-PCIE_65.patch
@@ -1,0 +1,173 @@
+From 8332152888aa03a14bef6e8d670b9b1a22c7398e Mon Sep 17 00:00:00 2001
+From: D Scott Phillips <scott@os.amperecomputing.com>
+Date: Fri, 13 Nov 2020 08:25:23 -0800
+Subject: [PATCH 01/10] arm64: Work around Ampere Altra erratum #82288 PCIE_65
+
+Altra's PCIe controller may generate incorrect addresses when receiving
+writes from the CPU with a discontiguous set of byte enables. Attempt to
+work around this by handing out Device-nGnRE maps instead of Normal
+Non-cacheable maps for PCIe memory areas.
+
+Signed-off-by: D Scott Phillips <scott@os.amperecomputing.com>
+---
+ Documentation/arm64/silicon-errata.rst |  3 +++
+ arch/arm64/Kconfig                     |  9 +++++++++
+ arch/arm64/include/asm/pci.h           |  4 ++++
+ arch/arm64/include/asm/pgtable.h       | 26 +++++++++++++++++++++-----
+ arch/arm64/mm/ioremap.c                | 18 ++++++++++++++++++
+ drivers/pci/quirks.c                   | 10 ++++++++++
+ 6 files changed, 65 insertions(+), 5 deletions(-)
+
+diff --git a/Documentation/arm64/silicon-errata.rst b/Documentation/arm64/silicon-errata.rst
+index 59daa4c21816..13f595e6fe18 100644
+--- a/Documentation/arm64/silicon-errata.rst
++++ b/Documentation/arm64/silicon-errata.rst
+@@ -52,6 +52,9 @@ stable kernels.
+ | Allwinner      | A64/R18         | UNKNOWN1        | SUN50I_ERRATUM_UNKNOWN1     |
+ +----------------+-----------------+-----------------+-----------------------------+
+ +----------------+-----------------+-----------------+-----------------------------+
++| Ampere         | Altra           | #82288          | ALTRA_ERRATUM_82288         |
+++----------------+-----------------+-----------------+-----------------------------+
+++----------------+-----------------+-----------------+-----------------------------+
+ | ARM            | Cortex-A53      | #826319         | ARM64_ERRATUM_826319        |
+ +----------------+-----------------+-----------------+-----------------------------+
+ | ARM            | Cortex-A53      | #827319         | ARM64_ERRATUM_827319        |
+diff --git a/arch/arm64/Kconfig b/arch/arm64/Kconfig
+index a1a828ca188c..7873f70e2b49 100644
+--- a/arch/arm64/Kconfig
++++ b/arch/arm64/Kconfig
+@@ -322,6 +322,15 @@ menu "ARM errata workarounds via the alternatives framework"
+ config ARM64_WORKAROUND_CLEAN_CACHE
+ 	bool
+ 
++config ALTRA_ERRATUM_82288
++	bool "Ampere Altra: 82288: PCIE_65: PCIe Root Port outbound write combining issue"
++	default y
++	help
++	  This option adds an alternative code sequence to work around
++	  Ampere Altra erratum 82288.
++
++	  If unsure, say Y.
++
+ config ARM64_ERRATUM_826319
+ 	bool "Cortex-A53: 826319: System might deadlock if a write cannot complete until read data is accepted"
+ 	default y
+diff --git a/arch/arm64/include/asm/pci.h b/arch/arm64/include/asm/pci.h
+index 70b323cf8300..5e3770c2ebea 100644
+--- a/arch/arm64/include/asm/pci.h
++++ b/arch/arm64/include/asm/pci.h
+@@ -17,6 +17,10 @@
+ #define pcibios_assign_all_busses() \
+ 	(pci_has_flag(PCI_REASSIGN_ALL_BUS))
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++extern bool __read_mostly have_altra_erratum_82288;
++#endif
++
+ #define ARCH_GENERIC_PCI_MMAP_RESOURCE	1
+ 
+ extern int isa_dma_bridge_buggy;
+diff --git a/arch/arm64/include/asm/pgtable.h b/arch/arm64/include/asm/pgtable.h
+index 3a057d427900..6b8884344fce 100644
+--- a/arch/arm64/include/asm/pgtable.h
++++ b/arch/arm64/include/asm/pgtable.h
+@@ -191,11 +191,6 @@ static inline pte_t pte_mkyoung(pte_t pte)
+ 	return set_pte_bit(pte, __pgprot(PTE_AF));
+ }
+ 
+-static inline pte_t pte_mkspecial(pte_t pte)
+-{
+-	return set_pte_bit(pte, __pgprot(PTE_SPECIAL));
+-}
+-
+ static inline pte_t pte_mkcont(pte_t pte)
+ {
+ 	pte = set_pte_bit(pte, __pgprot(PTE_CONT));
+@@ -442,6 +437,27 @@ static inline pmd_t pmd_mkdevmap(pmd_t pmd)
+ 	__pgprot_modify(prot, PTE_ATTRINDX_MASK, \
+ 			PTE_ATTRINDX(MT_NORMAL_NC) | PTE_PXN | PTE_UXN)
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++extern bool have_altra_erratum_82288;
++#endif
++
++static inline pte_t pte_mkspecial(pte_t pte)
++{
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++	phys_addr_t phys = __pte_to_phys(pte);
++	pgprot_t prot = __pgprot(pte_val(pte) & ~PTE_ADDR_MASK);
++
++	if (unlikely(have_altra_erratum_82288) &&
++	    (phys < 0x80000000 ||
++	     (phys >= 0x200000000000 && phys < 0x400000000000) ||
++	     (phys >= 0x600000000000 && phys < 0x800000000000))) {
++		pte = __pte(__phys_to_pte_val(phys) | pgprot_val(pgprot_device(prot)));
++	}
++#endif
++
++	return set_pte_bit(pte, __pgprot(PTE_SPECIAL));
++}
++
+ #define __HAVE_PHYS_MEM_ACCESS_PROT
+ struct file;
+ extern pgprot_t phys_mem_access_prot(struct file *file, unsigned long pfn,
+diff --git a/arch/arm64/mm/ioremap.c b/arch/arm64/mm/ioremap.c
+index 8dac7fcfb4bd..9d7042f0ab42 100644
+--- a/arch/arm64/mm/ioremap.c
++++ b/arch/arm64/mm/ioremap.c
+@@ -19,6 +19,19 @@
+ #include <asm/tlbflush.h>
+ #include <asm/pgalloc.h>
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++bool have_altra_erratum_82288 __read_mostly;
++EXPORT_SYMBOL(have_altra_erratum_82288);
++
++static bool is_altra_pci(phys_addr_t phys_addr, size_t size)
++{
++	phys_addr_t end = phys_addr + size;
++	return (phys_addr < 0x80000000 ||
++		(end > 0x200000000000 && phys_addr < 0x400000000000) ||
++		(end > 0x600000000000 && phys_addr < 0x800000000000));
++}
++#endif
++
+ static void __iomem *__ioremap_caller(phys_addr_t phys_addr, size_t size,
+ 				      pgprot_t prot, void *caller)
+ {
+@@ -54,6 +67,11 @@ static void __iomem *__ioremap_caller(phys_addr_t phys_addr, size_t size,
+ 	addr = (unsigned long)area->addr;
+ 	area->phys_addr = phys_addr;
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++	if (unlikely(have_altra_erratum_82288 && is_altra_pci(phys_addr, size)))
++		prot = pgprot_device(prot);
++#endif
++
+ 	err = ioremap_page_range(addr, addr + size, phys_addr, prot);
+ 	if (err) {
+ 		vunmap((void *)addr);
+diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
+index 2a4bc8df8563..431554ef8329 100644
+--- a/drivers/pci/quirks.c
++++ b/drivers/pci/quirks.c
+@@ -5774,6 +5774,16 @@ static void pci_fixup_no_pme(struct pci_dev *dev)
+ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_PERICOM, 0x400e, pci_fixup_no_pme);
+ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_PERICOM, 0x400f, pci_fixup_no_pme);
+ 
++
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++static void quirk_altra_erratum_82288(struct pci_dev *dev)
++{
++	pr_info_once("Write combining PCI maps disabled due to hardware erratum\n");
++	have_altra_erratum_82288 = true;
++}
++DECLARE_PCI_FIXUP_EARLY(PCI_VENDOR_ID_AMPERE, 0xe100, quirk_altra_erratum_82288);
++#endif
++
+ static void apex_pci_fixup_class(struct pci_dev *pdev)
+ {
+ 	pdev->class = (PCI_CLASS_SYSTEM_OTHER << 8) | pdev->class;
+-- 
+2.39.3
+

--- a/v5.4/0002-arm64-Add-a-fixup-handler-for-alignment-faults-in-aa.patch
+++ b/v5.4/0002-arm64-Add-a-fixup-handler-for-alignment-faults-in-aa.patch
@@ -1,0 +1,817 @@
+From bc0f4836c2f1c3c20bb8ffcdf1ffd83121f4a5e1 Mon Sep 17 00:00:00 2001
+From: D Scott Phillips <scott@os.amperecomputing.com>
+Date: Thu, 10 Dec 2020 00:07:19 -0800
+Subject: [PATCH 02/10] arm64: Add a fixup handler for alignment faults in
+ aarch64 code
+
+A later patch will hand out Device memory in some cases to code
+which expects a Normal memory type, as an errata workaround.
+Unaligned accesses to Device memory will fault though, so here we
+add a fixup handler to emulate faulting accesses, at a performance
+penalty.
+
+Many of the instructions in the Loads and Stores group are supported,
+but these groups are not handled here:
+
+ * Advanced SIMD load/store multiple structures
+ * Advanced SIMD load/store multiple structures (post-indexed)
+ * Advanced SIMD load/store single structure
+ * Advanced SIMD load/store single structure (post-indexed)
+ * Load/store memory tags
+ * Load/store exclusive
+ * LDAPR/STLR (unscaled immediate)
+ * Load register (literal) [cannot Alignment fault]
+ * Load/store register (unprivileged)
+ * Atomic memory operations
+ * Load/store register (pac)
+
+Instruction implementations are translated from the Exploration tools'
+ASL specifications.
+
+Signed-off-by: D Scott Phillips <scott@os.amperecomputing.com>
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/include/asm/insn.h |   1 +
+ arch/arm64/mm/fault.c         | 744 ++++++++++++++++++++++++++++++++++
+ 2 files changed, 745 insertions(+)
+
+diff --git a/arch/arm64/include/asm/insn.h b/arch/arm64/include/asm/insn.h
+index 39e7780bedd6..4accde26cbff 100644
+--- a/arch/arm64/include/asm/insn.h
++++ b/arch/arm64/include/asm/insn.h
+@@ -341,6 +341,7 @@ __AARCH64_INSN_FUNCS(eret,	0xFFFFFFFF, 0xD69F03E0)
+ __AARCH64_INSN_FUNCS(mrs,	0xFFF00000, 0xD5300000)
+ __AARCH64_INSN_FUNCS(msr_imm,	0xFFF8F01F, 0xD500401F)
+ __AARCH64_INSN_FUNCS(msr_reg,	0xFFF00000, 0xD5100000)
++__AARCH64_INSN_FUNCS(dc_zva,	0xFFFFFFE0, 0xD50B7420)
+ 
+ #undef	__AARCH64_INSN_FUNCS
+ 
+diff --git a/arch/arm64/mm/fault.c b/arch/arm64/mm/fault.c
+index 2a7339aeb1ad..61a8502894d5 100644
+--- a/arch/arm64/mm/fault.c
++++ b/arch/arm64/mm/fault.c
+@@ -5,6 +5,7 @@
+  * Copyright (C) 1995  Linus Torvalds
+  * Copyright (C) 1995-2004 Russell King
+  * Copyright (C) 2012 ARM Ltd.
++ * Copyright (C) 2020 Ampere Computing LLC
+  */
+ 
+ #include <linux/acpi.h>
+@@ -635,9 +636,752 @@ static int __kprobes do_translation_fault(unsigned long addr,
+ 	return 0;
+ }
+ 
++static int copy_from_user_io(void *to, const void __user *from, unsigned long n)
++{
++	const u8 __user *src = from;
++	u8 *dest = to;
++
++	for (; n; n--)
++		if (get_user(*dest++, src++))
++			break;
++	return n;
++}
++
++static int copy_to_user_io(void __user *to, const void *from, unsigned long n)
++{
++	const u8 *src = from;
++	u8 __user *dest = to;
++
++	for (; n; n--)
++		if (put_user(*src++, dest++))
++			break;
++	return n;
++}
++
++static int align_load(unsigned long addr, int sz, u64 *out)
++{
++	union {
++		u8 d8;
++		u16 d16;
++		u32 d32;
++		u64 d64;
++		char c[8];
++	} data;
++
++	if (sz != 1 && sz != 2 && sz != 4 && sz != 8)
++		return 1;
++	if (is_ttbr0_addr(addr)) {
++		if (copy_from_user_io(data.c, (const void __user *)addr, sz))
++			return 1;
++	} else
++		memcpy_fromio(data.c, (const void __iomem *)addr, sz);
++	switch (sz) {
++	case 1:
++		*out = data.d8;
++		break;
++	case 2:
++		*out = data.d16;
++		break;
++	case 4:
++		*out = data.d32;
++		break;
++	case 8:
++		*out = data.d64;
++		break;
++	default:
++		return 1;
++	}
++	return 0;
++}
++
++static int align_store(unsigned long addr, int sz, u64 val)
++{
++	union {
++		u8 d8;
++		u16 d16;
++		u32 d32;
++		u64 d64;
++		char c[8];
++	} data;
++
++	switch (sz) {
++	case 1:
++		data.d8 = val;
++		break;
++	case 2:
++		data.d16 = val;
++		break;
++	case 4:
++		data.d32 = val;
++		break;
++	case 8:
++		data.d64 = val;
++		break;
++	default:
++		return 1;
++	}
++	if (is_ttbr0_addr(addr)) {
++		if (copy_to_user_io((void __user *)addr, data.c, sz))
++			return 1;
++	} else
++		memcpy_toio((void __iomem *)addr, data.c, sz);
++	return 0;
++}
++
++static int align_dc_zva(unsigned long addr, struct pt_regs *regs)
++{
++	int bs = read_cpuid(DCZID_EL0) & 0xf;
++	int sz = 1 << (bs + 2);
++
++	addr &= ~(sz - 1);
++	if (is_ttbr0_addr(addr)) {
++		for (; sz; sz--) {
++			if (align_store(addr, 1, 0))
++				return 1;
++		}
++	} else
++		memset_io((void *)addr, 0, sz);
++	return 0;
++}
++
++static u64 get_vn_dt(int n, int t) {
++	u64 res;
++
++	switch (n) {
++#define V(n)						\
++	case n:						\
++		asm("cbnz %w1, 1f\n\t"			\
++		    "mov %0, v"#n".d[0]\n\t"		\
++		    "b 2f\n\t"				\
++		    "1: mov %0, v"#n".d[1]\n\t"		\
++		    "2:" : "=r" (res) : "r" (t));	\
++		break
++	V( 0); V( 1); V( 2); V( 3); V( 4); V( 5); V( 6); V( 7);
++	V( 8); V( 9); V(10); V(11); V(12); V(13); V(14); V(15);
++	V(16); V(17); V(18); V(19); V(20); V(21); V(22); V(23);
++	V(24); V(25); V(26); V(27); V(28); V(29); V(30); V(31);
++#undef V
++	default:
++		res = 0;
++		break;
++	}
++	return res;
++}
++
++static void set_vn_dt(int n, int t, u64 val) {
++	switch (n) {
++#define V(n)						\
++	case n:						\
++		asm("cbnz %w1, 1f\n\t"			\
++		    "mov v"#n".d[0], %0\n\t"		\
++		    "b 2f\n\t"				\
++		    "1: mov v"#n".d[1], %0\n\t"		\
++		    "2:" :: "r" (val), "r" (t));	\
++		break
++	V( 0); V( 1); V( 2); V( 3); V( 4); V( 5); V( 6); V( 7);
++	V( 8); V( 9); V(10); V(11); V(12); V(13); V(14); V(15);
++	V(16); V(17); V(18); V(19); V(20); V(21); V(22); V(23);
++	V(24); V(25); V(26); V(27); V(28); V(29); V(30); V(31);
++#undef Q
++	default:
++		break;
++	}
++}
++
++static int align_ldst_pair(u32 insn, struct pt_regs *regs)
++{
++	const u32 OPC = GENMASK(31, 30);
++	const u32 L_MASK = BIT(22);
++
++	int opc = FIELD_GET(OPC, insn);
++	int L = FIELD_GET(L_MASK, insn);
++
++	bool wback = !!(insn & BIT(23));
++	bool postindex = !(insn & BIT(24));
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int t2 = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT2, insn);
++	bool is_store = !L;
++	bool is_signed = !!(opc & 1);
++	int scale = 2 + (opc >> 1);
++	int datasize = 8 << scale;
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_7, insn);
++	s64 offset = sign_extend64(uoffset, 6) << scale;
++	u64 address;
++	u64 data1, data2;
++	u64 dbytes;
++
++	if ((is_store && (opc & 1)) || opc == 3)
++		return 1;
++
++	if (wback && (t == n || t2 == n) && n != 31)
++		return 1;
++
++	if (!is_store && t == t2)
++		return 1;
++
++	dbytes = datasize / 8;
++
++	address = regs_get_register(regs, n << 3);
++
++	if (!postindex)
++		address += offset;
++
++	if (is_store) {
++		data1 = pt_regs_read_reg(regs, t);
++		data2 = pt_regs_read_reg(regs, t2);
++		if (align_store(address, dbytes, data1) ||
++		    align_store(address + dbytes, dbytes, data2))
++			return 1;
++	} else {
++		if (align_load(address, dbytes, &data1) ||
++		    align_load(address + dbytes, dbytes, &data2))
++			return 1;
++		if (is_signed) {
++			data1 = sign_extend64(data1, datasize - 1);
++			data2 = sign_extend64(data2, datasize - 1);
++		}
++		pt_regs_write_reg(regs, t, data1);
++		pt_regs_write_reg(regs, t2, data2);
++	}
++
++	if (wback) {
++		if (postindex)
++			address += offset;
++		if (n == 31)
++			regs->sp = address;
++		else
++			pt_regs_write_reg(regs, n, address);
++	}
++
++	return 0;
++}
++
++static int align_ldst_pair_simdfp(u32 insn, struct pt_regs *regs)
++{
++	const u32 OPC = GENMASK(31, 30);
++	const u32 L_MASK = BIT(22);
++
++	int opc = FIELD_GET(OPC, insn);
++	int L = FIELD_GET(L_MASK, insn);
++
++	bool wback = !!(insn & BIT(23));
++	bool postindex = !(insn & BIT(24));
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int t2 = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT2, insn);
++	bool is_store = !L;
++	int scale = 2 + opc;
++	int datasize = 8 << scale;
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_7, insn);
++	s64 offset = sign_extend64(uoffset, 6) << scale;
++	u64 address;
++	u64 data1_d0, data1_d1, data2_d0, data2_d1;
++	u64 dbytes;
++
++	if (opc == 0x3)
++		return 1;
++
++	if (!is_store && t == t2)
++		return 1;
++
++	dbytes = datasize / 8;
++
++	address = regs_get_register(regs, n << 3);
++
++	if (!postindex)
++		address += offset;
++
++	if (is_store) {
++		data1_d0 = get_vn_dt(t, 0);
++		data2_d0 = get_vn_dt(t2, 0);
++		if (datasize == 128) {
++			data1_d1 = get_vn_dt(t, 1);
++			data2_d1 = get_vn_dt(t2, 1);
++			if (align_store(address, 8, data1_d0) ||
++			    align_store(address + 8, 8, data1_d1) ||
++			    align_store(address + 16, 8, data2_d0) ||
++			    align_store(address + 24, 8, data2_d1))
++				return 1;
++		} else {
++			if (align_store(address, dbytes, data1_d0) ||
++			    align_store(address + dbytes, dbytes, data2_d0))
++				return 1;
++		}
++	} else {
++		if (datasize == 128) {
++			if (align_load(address, 8, &data1_d0) ||
++			    align_load(address + 8, 8, &data1_d1) ||
++			    align_load(address + 16, 8, &data2_d0) ||
++			    align_load(address + 24, 8, &data2_d1))
++				return 1;
++		} else {
++			if (align_load(address, dbytes, &data1_d0) ||
++			    align_load(address + dbytes, dbytes, &data2_d0))
++				return 1;
++			data1_d1 = data2_d1 = 0;
++		}
++		set_vn_dt(t, 0, data1_d0);
++		set_vn_dt(t, 1, data1_d1);
++		set_vn_dt(t2, 0, data2_d0);
++		set_vn_dt(t2, 1, data2_d1);
++	}
++
++	if (wback) {
++		if (postindex)
++			address += offset;
++		if (n == 31)
++			regs->sp = address;
++		else
++			pt_regs_write_reg(regs, n, address);
++	}
++
++	return 0;
++}
++
++static int align_ldst_regoff(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++	const u32 OPTION = GENMASK(15, 13);
++	const u32 S = BIT(12);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	u32 option = FIELD_GET(OPTION, insn);
++	u32 s = FIELD_GET(S, insn);
++	int scale = size;
++	int extend_len = (option & 0x1) ? 64 : 32;
++	bool extend_unsigned = !(option & 0x4);
++	int shift = s ? scale : 0;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int m = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RM, insn);
++	bool is_store;
++	bool is_signed;
++	int regsize;
++	int datasize;
++	u64 offset;
++	u64 address;
++	u64 data;
++
++	if ((opc & 0x2) == 0) {
++		/* store or zero-extending load */
++		is_store = !(opc & 0x1);
++		regsize = size == 0x3 ? 64 : 32;
++		is_signed = false;
++	} else {
++		if (size == 0x3) {
++			if ((opc & 0x1) == 0) {
++				/* prefetch */
++				return 0;
++			} else {
++				/* undefined */
++				return 1;
++			}
++		} else {
++			/* sign-extending load */
++			is_store = false;
++			if (size == 0x2 && (opc & 0x1) == 0x1) {
++				/* undefined */
++				return 1;
++			}
++			regsize = (opc & 0x1) == 0x1 ? 32 : 64;
++			is_signed = true;
++		}
++	}
++
++	datasize = 8 << scale;
++
++	if (n == t && n != 31)
++		return 1;
++
++	offset = pt_regs_read_reg(regs, m);
++	if (extend_len == 32) {
++		offset &= (u32)~0;
++		if (!extend_unsigned)
++			sign_extend64(offset, 31);
++	}
++	offset <<= shift;
++
++	address = regs_get_register(regs, n << 3) + offset;
++
++	if (is_store) {
++		data = pt_regs_read_reg(regs, t);
++		if (align_store(address, datasize / 8, data))
++			return 1;
++	} else {
++		if (align_load(address, datasize / 8, &data))
++			return 1;
++		if (is_signed) {
++			if (regsize == 32)
++				data = sign_extend32(data, datasize - 1);
++			else
++				data = sign_extend64(data, datasize - 1);
++		}
++	}
++
++	return 0;
++}
++
++static int align_ldst_regoff_simdfp(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++	const u32 OPTION = GENMASK(15, 13);
++	const u32 S = BIT(12);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	u32 option = FIELD_GET(OPTION, insn);
++	u32 s = FIELD_GET(S, insn);
++	int scale = (opc & 0x2) << 1 | size;
++	int extend_len = (option & 0x1) ? 64 : 32;
++	bool extend_unsigned = !(option & 0x4);
++	int shift = s ? scale : 0;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int m = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RM, insn);
++	bool is_store = !(opc & BIT(0));
++	int datasize;
++	u64 offset;
++	u64 address;
++	u64 data_d0, data_d1;
++
++	if ((opc & 0x2) == 0)
++		return 1;
++
++	datasize = 8 << scale;
++
++	if (n == t && n != 31)
++		return 1;
++
++	offset = pt_regs_read_reg(regs, m);
++	if (extend_len == 32) {
++		offset &= (u32)~0;
++		if (!extend_unsigned)
++			sign_extend64(offset, 31);
++	}
++	offset <<= shift;
++
++	address = regs_get_register(regs, n << 3) + offset;
++
++	if (is_store) {
++		data_d0 = get_vn_dt(t, 0);
++		if (datasize == 128) {
++			data_d1 = get_vn_dt(t, 1);
++			if (align_store(address, 8, data_d0) ||
++			    align_store(address + 8, 8, data_d1))
++				return 1;
++		} else {
++			if (align_store(address, datasize / 8, data_d0))
++				return 1;
++		}
++	} else {
++		if (datasize == 128) {
++			if (align_load(address, 8, &data_d0) ||
++			    align_load(address + 8, 8, &data_d1))
++				return 1;
++		} else {
++			if (align_load(address, datasize / 8, &data_d0))
++				return 1;
++			data_d1 = 0;
++		}
++		set_vn_dt(t, 0, data_d0);
++		set_vn_dt(t, 1, data_d1);
++	}
++
++	return 0;
++}
++
++static int align_ldst_imm(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	bool wback = !(insn & BIT(24)) && !!(insn & BIT(10));
++	bool postindex = wback && !(insn & BIT(11));
++	int scale = size;
++	u64 offset;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	bool is_store;
++	bool is_signed;
++	int regsize;
++	int datasize;
++	u64 address;
++	u64 data;
++
++	if (!(insn & BIT(24))) {
++		u64 uoffset =
++			aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++		offset = sign_extend64(uoffset, 8);
++	} else {
++		offset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_12, insn);
++		offset <<= scale;
++	}
++
++	if ((opc & 0x2) == 0) {
++		/* store or zero-extending load */
++		is_store = !(opc & 0x1);
++		regsize = size == 0x3 ? 64 : 32;
++		is_signed = false;
++	} else {
++		if (size == 0x3) {
++			if (FIELD_GET(GENMASK(11, 10), insn) == 0 && (opc & 0x1) == 0) {
++				/* prefetch */
++				return 0;
++			} else {
++				/* undefined */
++				return 1;
++			}
++		} else {
++			/* sign-extending load */
++			is_store = false;
++			if (size == 0x2 && (opc & 0x1) == 0x1) {
++				/* undefined */
++				return 1;
++			}
++			regsize = (opc & 0x1) == 0x1 ? 32 : 64;
++			is_signed = true;
++		}
++	}
++
++	datasize = 8 << scale;
++
++	if (n == t && n != 31)
++		return 1;
++
++	address = regs_get_register(regs, n << 3);
++
++	if (!postindex)
++		address += offset;
++
++	if (is_store) {
++		data = pt_regs_read_reg(regs, t);
++		if (align_store(address, datasize / 8, data))
++			return 1;
++	} else {
++		if (align_load(address, datasize / 8, &data))
++			return 1;
++		if (is_signed) {
++			if (regsize == 32)
++				data = sign_extend32(data, datasize - 1);
++			else
++				data = sign_extend64(data, datasize - 1);
++		}
++		pt_regs_write_reg(regs, t, data);
++	}
++
++	if (wback) {
++		if (postindex)
++			address += offset;
++		if (n == 31)
++			regs->sp = address;
++		else
++			pt_regs_write_reg(regs, n, address);
++	}
++
++	return 0;
++}
++
++static int align_ldst_imm_simdfp(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	bool wback = !(insn & BIT(24)) && !!(insn & BIT(10));
++	bool postindex = wback && !(insn & BIT(11));
++	int scale = (opc & 0x2) << 1 | size;
++	u64 offset;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	bool is_store = !(opc & BIT(0)) ;
++	int datasize;
++	u64 address;
++	u64 data_d0, data_d1;
++
++	if (scale > 4)
++		return 1;
++
++	if (!(insn & BIT(24))) {
++		u64 uoffset =
++			aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++		offset = sign_extend64(uoffset, 8);
++	} else {
++		offset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_12, insn);
++		offset <<= scale;
++	}
++
++	datasize = 8 << scale;
++
++	address = regs_get_register(regs, n << 3);
++
++	if (!postindex)
++		address += offset;
++
++	if (is_store) {
++		data_d0 = get_vn_dt(t, 0);
++		if (datasize == 128) {
++			data_d1 = get_vn_dt(t, 1);
++			if (align_store(address, 8, data_d0) ||
++			    align_store(address + 8, 8, data_d1))
++				return 1;
++		} else {
++			if (align_store(address, datasize / 8, data_d0))
++				return 1;
++		}
++	} else {
++		if (datasize == 128) {
++			if (align_load(address, 8, &data_d0) ||
++			    align_load(address + 8, 8, &data_d1))
++				return 1;
++		} else {
++			if (align_load(address, datasize / 8, &data_d0))
++				return 1;
++			data_d1 = 0;
++		}
++		set_vn_dt(t, 0, data_d0);
++		set_vn_dt(t, 1, data_d1);
++	}
++
++	if (wback) {
++		if (postindex)
++			address += offset;
++		if (n == 31)
++			regs->sp = address;
++		else
++			pt_regs_write_reg(regs, n, address);
++	}
++
++	return 0;
++}
++
++static int align_ldst(u32 insn, struct pt_regs *regs)
++{
++	const u32 op0 = FIELD_GET(GENMASK(31, 28), insn);
++	const u32 op1 = FIELD_GET(BIT(26), insn);
++	const u32 op2 = FIELD_GET(GENMASK(24, 23), insn);
++	const u32 op3 = FIELD_GET(GENMASK(21, 16), insn);
++	const u32 op4 = FIELD_GET(GENMASK(11, 10), insn);
++
++	if ((op0 & 0x3) == 0x2) {
++		/*
++		 * |------+-----+-----+-----+-----+-----------------------------------------|
++		 * | op0  | op1 | op2 | op3 | op4 | Decode group                            |
++		 * |------+-----+-----+-----+-----+-----------------------------------------|
++		 * | xx10 | -   |  00 | -   | -   | Load/store no-allocate pair (offset)    |
++		 * | xx10 | -   |  01 | -   | -   | Load/store register pair (post-indexed) |
++		 * | xx10 | -   |  10 | -   | -   | Load/store register pair (offset)       |
++		 * | xx10 | -   |  11 | -   | -   | Load/store register pair (pre-indexed)  |
++		 * |------+-----+-----+-----+-----+-----------------------------------------|
++		 */
++
++		if (op1 == 0) { /* V == 0 */
++			/* general */
++			return align_ldst_pair(insn, regs);
++		} else {
++			/* simdfp */
++			return align_ldst_pair_simdfp(insn, regs);
++		}
++	} else if ((op0 & 0x3) == 0x3 &&
++		   (((op2 & 0x2) == 0 && (op3 & 0x20) == 0 && op4 != 0x2) ||
++		    ((op2 & 0x2) == 0x2))) {
++		/*
++		 * |------+-----+-----+--------+-----+----------------------------------------------|
++		 * | op0  | op1 | op2 |    op3 | op4 | Decode group                                 |
++		 * |------+-----+-----+--------+-----+----------------------------------------------|
++		 * | xx11 | -   |  0x | 0xxxxx |  00 | Load/store register (unscaled immediate)     |
++		 * | xx11 | -   |  0x | 0xxxxx |  01 | Load/store register (immediate post-indexed) |
++		 * | xx11 | -   |  0x | 0xxxxx |  11 | Load/store register (immediate pre-indexed)  |
++		 * | xx11 | -   |  1x |      - |   - | Load/store register (unsigned immediate)     |
++		 * |------+-----+-----+--------+-----+----------------------------------------------|
++		 */
++
++		if (op1 == 0) {  /* V == 0 */
++			/* general */
++			return align_ldst_imm(insn, regs);
++		} else {
++			/* simdfp */
++			return align_ldst_imm_simdfp(insn, regs);
++		}
++	} else if ((op0 & 0x3) == 0x3 && (op2 & 0x2) == 0 &&
++		   (op3 & 0x20) == 0x20 && op4 == 0x2) {
++		/*
++		 * |------+-----+-----+--------+-----+---------------------------------------|
++		 * | op0  | op1 | op2 |    op3 | op4 |                                       |
++		 * |------+-----+-----+--------+-----+---------------------------------------|
++		 * | xx11 | -   |  0x | 1xxxxx |  10 | Load/store register (register offset) |
++		 * |------+-----+-----+--------+-----+---------------------------------------|
++		 */
++		if (op1 == 0) { /* V == 0 */
++			/* general */
++			return align_ldst_regoff(insn, regs);
++		} else {
++			/* simdfp */
++			return align_ldst_regoff_simdfp(insn, regs);
++		}
++	} else
++		return 1;
++}
++
++static int fixup_alignment(unsigned long addr, unsigned int esr,
++			   struct pt_regs *regs)
++{
++	u32 insn;
++	int res;
++
++	if (user_mode(regs)) {
++		__le32 insn_le;
++
++		if (!is_ttbr0_addr(addr))
++			return 1;
++
++		if (get_user(insn_le,
++			     (__le32 __user *)instruction_pointer(regs)))
++			return 1;
++		insn = le32_to_cpu(insn_le);
++	} else {
++		if (aarch64_insn_read((void *)instruction_pointer(regs), &insn))
++			return 1;
++	}
++
++	switch (aarch64_get_insn_class(insn)) {
++	case AARCH64_INSN_CLS_BR_SYS:
++		if (aarch64_insn_is_dc_zva(insn))
++			res = align_dc_zva(addr, regs);
++		else
++			res = 1;
++		break;
++	case AARCH64_INSN_CLS_LDST:
++		res = align_ldst(insn, regs);
++		break;
++	default:
++		res = 1;
++	}
++	if (!res) {
++		instruction_pointer_set(regs, instruction_pointer(regs) + 4);
++	}
++	return res;
++}
++
+ static int do_alignment_fault(unsigned long addr, unsigned int esr,
+ 			      struct pt_regs *regs)
+ {
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++	if (!fixup_alignment(addr, esr, regs))
++		return 0;
++#endif
+ 	do_bad_area(addr, esr, regs);
+ 	return 0;
+ }
+-- 
+2.39.3
+

--- a/v5.4/0003-arm64-Add-alignment-faults-handler-for-Advanced-SIMD.patch
+++ b/v5.4/0003-arm64-Add-alignment-faults-handler-for-Advanced-SIMD.patch
@@ -1,0 +1,207 @@
+From 6a71186731b128346824146be977c08ef7da4cc4 Mon Sep 17 00:00:00 2001
+From: D Scott Phillips <scott@os.amperecomputing.com>
+Date: Thu, 3 Mar 2022 15:43:08 +0800
+Subject: [PATCH 03/10] arm64: Add alignment faults handler for Advanced SIMD
+ load/store single
+
+Signed-off-by: D Scott Phillips <scott@os.amperecomputing.com>
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/mm/fault.c | 160 +++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 159 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/mm/fault.c b/arch/arm64/mm/fault.c
+index 61a8502894d5..205461394cc5 100644
+--- a/arch/arm64/mm/fault.c
++++ b/arch/arm64/mm/fault.c
+@@ -740,7 +740,7 @@ static int align_dc_zva(unsigned long addr, struct pt_regs *regs)
+ 				return 1;
+ 		}
+ 	} else
+-		memset_io((void *)addr, 0, sz);
++		memset_io((void __iomem *)addr, 0, sz);
+ 	return 0;
+ }
+ 
+@@ -788,6 +788,44 @@ static void set_vn_dt(int n, int t, u64 val) {
+ 	}
+ }
+ 
++static u64 replicate64(u64 val, int bits)
++{
++	switch (bits) {
++	case 8:
++		val = (val << 8) | (val & 0xff);
++		fallthrough;
++	case 16:
++		val = (val << 16) | (val & 0xffff);
++		fallthrough;
++	case 32:
++		val = (val << 32) | (val & 0xffffffff);
++		break;
++	default:
++		break;
++	}
++	return val;
++}
++
++static u64 elem_get(u64 hi, u64 lo, int index, int esize)
++{
++	int shift = index * esize;
++	u64 mask = GENMASK(esize - 1, 0);
++	if (shift < 64)
++		return (lo >> shift) & mask;
++	else
++		return (hi >> (shift - 64)) & mask;
++}
++
++static void elem_set(u64 *hi, u64 *lo, int index, int esize, u64 val)
++{
++	int shift = index * esize;
++	u64 mask = GENMASK(esize - 1, 0);
++	if (shift < 64)
++		*lo = (*lo & ~(mask << shift)) | ((val & mask) << shift);
++	else
++		*hi = (*hi & ~(mask << (shift - 64))) | ((val & mask) << (shift - 64));
++}
++
+ static int align_ldst_pair(u32 insn, struct pt_regs *regs)
+ {
+ 	const u32 OPC = GENMASK(31, 30);
+@@ -1267,6 +1305,114 @@ static int align_ldst_imm_simdfp(u32 insn, struct pt_regs *regs)
+ 	return 0;
+ }
+ 
++static int align_ldst_vector_single(u32 insn, struct pt_regs *regs)
++{
++	const u32 Q_MASK = BIT(30);
++	const u32 L_MASK = BIT(22);
++	const u32 R_MASK = BIT(21);
++	const u32 OPCODE = GENMASK(15, 13);
++	const u32 S_MASK = BIT(12);
++	const u32 SIZE = GENMASK(11, 10);
++	u32 Q = FIELD_GET(Q_MASK, insn);
++	u32 L = FIELD_GET(L_MASK, insn);
++	u32 R = FIELD_GET(R_MASK, insn);
++	u32 opcode = FIELD_GET(OPCODE, insn);
++	u32 S = FIELD_GET(S_MASK, insn);
++	u32 size = FIELD_GET(SIZE, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int m = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RM, insn);
++	bool wback = !!(insn & BIT(23));
++	int init_scale = opcode >> 1;
++	int scale = init_scale;
++	int selem = (((opcode & 1) << 1) | R) + 1;
++	bool replicate = false;
++	int index;
++	int datasize;
++	int esize;
++	u64 address;
++	u64 offs;
++	u64 rval_d0, rval_d1;
++	u64 element;
++	int ebytes;
++	int s;
++	u64 data;
++	switch (scale) {
++	case 3:
++		if (!L || S)
++			return 1;
++		scale = size;
++		replicate = true;
++		break;
++	case 0:
++		index = (Q << 3) | (S << 2) | size;
++		break;
++	case 1:
++		if (size & 1)
++			return 1;
++		index = (Q << 2) | (S << 1) | (size >> 1);
++		break;
++	case 2:
++		if (size & 2)
++			return 1;
++		if (!(size & 1))
++			index = (Q << 1) | S;
++		else {
++			if (S)
++				return 1;
++			index = Q;
++			scale = 3;
++		}
++		break;
++	}
++	datasize = Q ? 128 : 64;
++	esize = 8 << scale;
++	ebytes = esize / 8;
++	address = regs_get_register(regs, n << 3);
++	offs = 0;
++	if (replicate) {
++		for (s = 0; s < selem; s++) {
++			if (align_load(address + offs, ebytes, &element))
++				return 1;
++			data = replicate64(element, esize);
++			set_vn_dt(t, 0, data);
++			if (datasize == 128)
++				set_vn_dt(t, 1, data);
++			else
++				set_vn_dt(t, 1, 0);
++			offs += ebytes;
++			t = (t + 1) & 31;
++		}
++	} else {
++		for (s = 0; s < selem; s++) {
++			rval_d0 = get_vn_dt(t, 0);
++			rval_d1 = get_vn_dt(t, 1);
++			if (L) {
++				if (align_load(address + offs, ebytes, &data))
++					return 1;
++				elem_set(&rval_d1, &rval_d0, index, esize, data);
++				set_vn_dt(t, 0, rval_d0);
++				set_vn_dt(t, 1, rval_d1);
++			} else {
++				data = elem_get(rval_d1, rval_d0, index, esize);
++				if (align_store(address + offs, ebytes, data))
++					return 1;
++			}
++			offs += ebytes;
++			t = (t + 1) & 31;
++		}
++	}
++	if (wback) {
++		if (m != 31)
++			offs = regs_get_register(regs, m << 3);
++		if (n == 31)
++			regs->sp = address + offs;
++		else
++			pt_regs_write_reg(regs, n, address + offs);
++	}
++	return 0;
++}
++
+ static int align_ldst(u32 insn, struct pt_regs *regs)
+ {
+ 	const u32 op0 = FIELD_GET(GENMASK(31, 28), insn);
+@@ -1331,6 +1477,18 @@ static int align_ldst(u32 insn, struct pt_regs *regs)
+ 			/* simdfp */
+ 			return align_ldst_regoff_simdfp(insn, regs);
+ 		}
++	} else if ((op0 & 0xb) == 0 && op1 == 1 &&
++		   ((op2 == 2 && ((op3 & 0x1f) == 0)) || op2 == 3)) {
++		/*
++		 * |------+-----+-----+--------+-----+-------------------------------------------|
++		 * | op0  | op1 | op2 |    op3 | op4 |                                           |
++		 * |------+-----+-----+--------+-----+-------------------------------------------|
++		 * | 0x00 |   1 |  10 | x00000 |   - | Advanced SIMD load/store single structure |
++		 * | 0x00 |   1 |  11 |      - |   - | Advanced SIMD load/store single structure |
++		 * |      |     |     |        |     |   (post-indexed)                          |
++		 * |------+-----+-----+--------+-----+-------------------------------------------|
++		 */
++		return align_ldst_vector_single(insn, regs);
+ 	} else
+ 		return 1;
+ }
+-- 
+2.39.3
+

--- a/v5.4/0004-arm64-remove-the-hardcode-about-PCI-address-checking.patch
+++ b/v5.4/0004-arm64-remove-the-hardcode-about-PCI-address-checking.patch
@@ -1,0 +1,139 @@
+From f11aba46312c61c045a4b479f6fd2e9442a3a36e Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Fri, 8 Apr 2022 20:43:33 +0000
+Subject: [PATCH 04/10] arm64: remove the hardcode about PCI address checking
+
+Copy name in find_next_iomem_res() for checking the PCI
+address.
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/include/asm/pgtable.h |  7 ++----
+ arch/arm64/mm/ioremap.c          |  4 ++-
+ include/linux/pci.h              |  3 +++
+ kernel/resource.c                | 43 ++++++++++++++++++++++++++++++++
+ 4 files changed, 51 insertions(+), 6 deletions(-)
+
+diff --git a/arch/arm64/include/asm/pgtable.h b/arch/arm64/include/asm/pgtable.h
+index 6b8884344fce..82baddf80fff 100644
+--- a/arch/arm64/include/asm/pgtable.h
++++ b/arch/arm64/include/asm/pgtable.h
+@@ -438,7 +438,7 @@ static inline pmd_t pmd_mkdevmap(pmd_t pmd)
+ 			PTE_ATTRINDX(MT_NORMAL_NC) | PTE_PXN | PTE_UXN)
+ 
+ #ifdef CONFIG_ALTRA_ERRATUM_82288
+-extern bool have_altra_erratum_82288;
++extern bool range_is_pci(phys_addr_t, size_t);
+ #endif
+ 
+ static inline pte_t pte_mkspecial(pte_t pte)
+@@ -447,10 +447,7 @@ static inline pte_t pte_mkspecial(pte_t pte)
+ 	phys_addr_t phys = __pte_to_phys(pte);
+ 	pgprot_t prot = __pgprot(pte_val(pte) & ~PTE_ADDR_MASK);
+ 
+-	if (unlikely(have_altra_erratum_82288) &&
+-	    (phys < 0x80000000 ||
+-	     (phys >= 0x200000000000 && phys < 0x400000000000) ||
+-	     (phys >= 0x600000000000 && phys < 0x800000000000))) {
++	if (range_is_pci(phys, PAGE_SIZE)) {
+ 		pte = __pte(__phys_to_pte_val(phys) | pgprot_val(pgprot_device(prot)));
+ 	}
+ #endif
+diff --git a/arch/arm64/mm/ioremap.c b/arch/arm64/mm/ioremap.c
+index 9d7042f0ab42..8658cc2fb58e 100644
+--- a/arch/arm64/mm/ioremap.c
++++ b/arch/arm64/mm/ioremap.c
+@@ -14,6 +14,7 @@
+ #include <linux/vmalloc.h>
+ #include <linux/io.h>
+ #include <linux/memblock.h>
++#include <linux/pci.h>
+ 
+ #include <asm/fixmap.h>
+ #include <asm/tlbflush.h>
+@@ -68,7 +69,8 @@ static void __iomem *__ioremap_caller(phys_addr_t phys_addr, size_t size,
+ 	area->phys_addr = phys_addr;
+ 
+ #ifdef CONFIG_ALTRA_ERRATUM_82288
+-	if (unlikely(have_altra_erratum_82288 && is_altra_pci(phys_addr, size)))
++	if ((pgprot_val(prot) != pgprot_val(pgprot_device(prot))) &&
++			range_is_pci(phys_addr, size))
+ 		prot = pgprot_device(prot);
+ #endif
+ 
+diff --git a/include/linux/pci.h b/include/linux/pci.h
+index fc343d123127..5820c5b17544 100644
+--- a/include/linux/pci.h
++++ b/include/linux/pci.h
+@@ -2406,4 +2406,7 @@ void pci_uevent_ers(struct pci_dev *pdev, enum  pci_ers_result err_type);
+ #define pci_info_ratelimited(pdev, fmt, arg...) \
+ 	dev_info_ratelimited(&(pdev)->dev, fmt, ##arg)
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++extern bool range_is_pci(phys_addr_t phys_addr, size_t size);
++#endif
+ #endif /* LINUX_PCI_H */
+diff --git a/kernel/resource.c b/kernel/resource.c
+index 841737bbda9e..62326c4b144f 100644
+--- a/kernel/resource.c
++++ b/kernel/resource.c
+@@ -386,6 +386,7 @@ static int find_next_iomem_res(resource_size_t start, resource_size_t end,
+ 		res->end = min(end, p->end);
+ 		res->flags = p->flags;
+ 		res->desc = p->desc;
++		res->name = p->name;
+ 	}
+ 
+ 	read_unlock(&resource_lock);
+@@ -513,6 +514,48 @@ int __weak page_is_ram(unsigned long pfn)
+ }
+ EXPORT_SYMBOL_GPL(page_is_ram);
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++/* Return 0 on success, else return 1 */
++static int pci_addr_check(struct resource *r, void *p)
++{
++	if (!r->name)
++		return 1;
++
++	if (strlen(r->name) <= 2)
++		return 1;
++
++	if (memcmp(r->name, "PCI", 3))
++		return 1;
++
++	/* Success */
++	return 0;
++}
++
++bool range_is_pci(phys_addr_t phys_addr, size_t size)
++{
++	u64 start, end;
++	int ret;
++
++	start = phys_addr;
++	end = phys_addr + size;
++
++	/* Check the 32bit */
++	ret = walk_iomem_res_desc(IORES_DESC_NONE, IORESOURCE_MEM,
++			start, end, NULL, pci_addr_check);
++	if (!ret)
++		return true;
++
++	/* Check the 64bit */
++	ret = walk_iomem_res_desc(IORES_DESC_NONE, IORESOURCE_MEM_64,
++			start, end, NULL, pci_addr_check);
++	if (!ret)
++		return true;
++
++	return false;
++}
++EXPORT_SYMBOL_GPL(range_is_pci);
++#endif
++
+ /**
+  * region_intersects() - determine intersection of region with known resources
+  * @start: region start address
+-- 
+2.39.3
+

--- a/v5.4/0005-arm64-Add-new-code-for-unaligned-pcie-access.patch
+++ b/v5.4/0005-arm64-Add-new-code-for-unaligned-pcie-access.patch
@@ -1,0 +1,313 @@
+From 63881cfc9e32b92f266cc334f79c6476223d3e57 Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Tue, 12 Apr 2022 12:09:54 +0000
+Subject: [PATCH 05/10] arm64: Add new code for unaligned pcie access
+
+Add a new function align_ldst_new to handle the rest instructions
+if align_ldst() fails.
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/mm/fault.c               |  18 ++-
+ arch/arm64/mm/pcie_unalign_access.c | 235 ++++++++++++++++++++++++++++
+ 2 files changed, 252 insertions(+), 1 deletion(-)
+ create mode 100644 arch/arm64/mm/pcie_unalign_access.c
+
+diff --git a/arch/arm64/mm/fault.c b/arch/arm64/mm/fault.c
+index 205461394cc5..61d0a5a42718 100644
+--- a/arch/arm64/mm/fault.c
++++ b/arch/arm64/mm/fault.c
+@@ -1493,11 +1493,15 @@ static int align_ldst(u32 insn, struct pt_regs *regs)
+ 		return 1;
+ }
+ 
++#include "pcie_unalign_access.c"
++
+ static int fixup_alignment(unsigned long addr, unsigned int esr,
+ 			   struct pt_regs *regs)
+ {
+ 	u32 insn;
+ 	int res;
++	struct pt_regs t = *regs;
++	int type;
+ 
+ 	if (user_mode(regs)) {
+ 		__le32 insn_le;
+@@ -1514,7 +1518,10 @@ static int fixup_alignment(unsigned long addr, unsigned int esr,
+ 			return 1;
+ 	}
+ 
+-	switch (aarch64_get_insn_class(insn)) {
++	pr_debug("start to handle insn:%x\n", insn);
++
++	type = aarch64_get_insn_class(insn);
++	switch (type) {
+ 	case AARCH64_INSN_CLS_BR_SYS:
+ 		if (aarch64_insn_is_dc_zva(insn))
+ 			res = align_dc_zva(addr, regs);
+@@ -1523,12 +1530,21 @@ static int fixup_alignment(unsigned long addr, unsigned int esr,
+ 		break;
+ 	case AARCH64_INSN_CLS_LDST:
+ 		res = align_ldst(insn, regs);
++		if (res) {
++			/* Try it again, copy back if we succeed */
++			res = align_ldst_new(insn, &t);
++			if (!res)
++				*regs = t;
++		}
+ 		break;
+ 	default:
+ 		res = 1;
+ 	}
+ 	if (!res) {
+ 		instruction_pointer_set(regs, instruction_pointer(regs) + 4);
++	} else {
++		pr_err("cannot handle insn:%x, type:%d\n", insn, type);
++		dump_stack();
+ 	}
+ 	return res;
+ }
+diff --git a/arch/arm64/mm/pcie_unalign_access.c b/arch/arm64/mm/pcie_unalign_access.c
+new file mode 100644
+index 000000000000..f7c948985296
+--- /dev/null
++++ b/arch/arm64/mm/pcie_unalign_access.c
+@@ -0,0 +1,235 @@
++struct ldst_filter {
++	u32 mask;
++	u32 arm_code;
++	char *name;
++	int (*handler)(struct ldst_filter *, u32, struct pt_regs*);
++};
++
++static int ldst_default(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	pr_alert("instruction :%x(%s) is not implemented.\n", insn, f->name);
++	return 1;
++}
++
++/*
++ * |------+-----+-----+-----+-----+-----------------------------------------|
++ * | op0  | op1 | op2 | op3 | op4 | Decode group                            |
++ * |------+-----+-----+-----+-----+-----------------------------------------|
++ * | xx10 | -   |  00 | -   | -   | Load/store no-allocate pair (offset)    |
++ * | xx10 | -   |  01 | -   | -   | Load/store register pair (post-indexed) |
++ * | xx10 | -   |  10 | -   | -   | Load/store register pair (offset)       |
++ * | xx10 | -   |  11 | -   | -   | Load/store register pair (pre-indexed)  |
++ * |------+-----+-----+-----+-----+-----------------------------------------|
++ */
++static int ldst_type_pair(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	/* The bit 26 is used for SIMD only, please see the spec */
++	if (insn & BIT(26))
++		return align_ldst_pair_simdfp(insn, regs);
++	else
++		return align_ldst_pair(insn, regs);
++}
++
++/*
++ * |------+-----+-----+--------+-----+----------------------------------------------|
++ * | op0  | op1 | op2 |    op3 | op4 | Decode group                                 |
++ * |------+-----+-----+--------+-----+----------------------------------------------|
++ * | xx11 | -   |  0x | 0xxxxx |  00 | Load/store register (unscaled immediate)     |
++ * | xx11 | -   |  0x | 0xxxxx |  01 | Load/store register (immediate post-indexed) |
++ * | xx11 | -   |  0x | 0xxxxx |  11 | Load/store register (immediate pre-indexed)  |
++ * | xx11 | -   |  1x |      - |   - | Load/store register (unsigned immediate)     |
++ * |------+-----+-----+--------+-----+----------------------------------------------|
++ */
++static int ldst_type_imm(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	/* The bit 26 is used for SIMD only, please see the spec */
++	if (insn & BIT(26))
++		return align_ldst_imm_simdfp(insn, regs);
++	else
++		return align_ldst_imm(insn, regs);
++}
++
++/*
++ * |------+-----+-----+--------+-----+---------------------------------------|
++ * | op0  | op1 | op2 |    op3 | op4 |                                       |
++ * |------+-----+-----+--------+-----+---------------------------------------|
++ * | xx11 | -   |  0x | 1xxxxx |  10 | Load/store register (register offset) |
++ * |------+-----+-----+--------+-----+---------------------------------------|
++ */
++static int ldst_type_regoff(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	/* The bit 26 is used for SIMD only, please see the spec */
++	if (insn & BIT(26))
++		return align_ldst_regoff_simdfp(insn, regs);
++	else
++		return align_ldst_regoff(insn, regs);
++}
++
++/*
++ * |------+-----+-----+--------+-----+-------------------------------------------|
++ * | op0  | op1 | op2 |    op3 | op4 |                                           |
++ * |------+-----+-----+--------+-----+-------------------------------------------|
++ * | 0x00 |   1 |  10 | x00000 |   - | Advanced SIMD load/store single structure |
++ * | 0x00 |   1 |  11 |      - |   - | Advanced SIMD load/store single structure |
++ * |      |     |     |        |     |   (post-indexed)                          |
++ * |------+-----+-----+--------+-----+-------------------------------------------|
++ */
++static int ldst_type_vector_single(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	return align_ldst_vector_single(insn, regs);
++}
++
++/* Please see the C4.1.66 */
++static const struct ldst_filter ldst_filters[] = {
++	{
++		.mask		= BIT(31) | GENMASK(29, 28) | BIT(26)
++					| GENMASK(24, 23) | BIT(21),
++		.arm_code	= BIT(21),
++		.name		= "Compare and swap pair",
++		.handler	= ldst_default,
++	}, {
++		.mask		= BIT(31) | GENMASK(29, 28) | BIT(26)
++					| GENMASK(24, 23) | GENMASK(21, 16),
++		.arm_code	= BIT(26),
++		.name		= "Advanced SIMD load/store multiple structures",
++		.handler	= ldst_default,
++	}, {
++		.mask		= BIT(31) | GENMASK(29, 28) | BIT(26)
++					| GENMASK(24, 23) | BIT(21),
++		.arm_code	= BIT(26) | BIT(23),
++		.name		= "Advanced SIMD load/store multiple structures(post-indexed)",
++		.handler	= ldst_default,
++	}, {
++		.mask		= BIT(31) | GENMASK(29, 28) | BIT(26)
++					| GENMASK(24, 23) | GENMASK(20, 16),
++		.arm_code	= BIT(26) | BIT(24),
++		.name		= "Advanced SIMD load/store single structures",
++		.handler	= ldst_type_vector_single,
++	}, {
++		.mask		= BIT(31) | GENMASK(29, 28) | BIT(26) | GENMASK(24, 23),
++		.arm_code	= BIT(26) | BIT(24) | BIT(23),
++		.name		= "Advanced SIMD load/store single structures(post-indexed)",
++		.handler	= ldst_type_vector_single,
++	}, {
++		.mask		= GENMASK(31, 28) | BIT(26) | BIT(24) | BIT(21),
++		.arm_code	= BIT(31) | BIT(30) | BIT(28) | BIT(24) | BIT(21),
++		.name		= "Load/store memory tags",
++		.handler	= ldst_default,
++	}, {
++		.mask		= BIT(31) | GENMASK(29, 28) | BIT(26)
++					| GENMASK(24, 23) | BIT(21),
++		.arm_code	= BIT(31) | BIT(21),
++		.name		= "Load/store exclusive pair",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(26) | GENMASK(24, 23) | BIT(21),
++		.arm_code	= 0,
++		.name		= "Load/store exclusive register",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(26) | GENMASK(24, 23) | BIT(21),
++		.arm_code	= BIT(23),
++		.name		= "Load/store ordered",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(26) | GENMASK(24, 23) | BIT(21),
++		.arm_code	= BIT(23) | BIT(21),
++		.name		= "Compare and swap",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(26) | BIT(24) | BIT(21) |
++					GENMASK(11, 10),
++		.arm_code	= BIT(28) | BIT(24),
++		.name		= "LDAPR/STLR(unscaled immediate)",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24),
++		.arm_code	= BIT(28),
++		.name		= "Load register(literal)",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(28) | BIT(10),
++		.name		= "Memory Copy and Memory Set",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | GENMASK(24, 23),
++		.arm_code	= BIT(29),
++		.name		= "Load/store no-allocate pair(offset)",
++		.handler	= ldst_type_pair,
++	}, {
++		.mask		= GENMASK(29, 28) | GENMASK(24, 23),
++		.arm_code	= BIT(29) | BIT(23),
++		.name		= "Load/store register pair(post-indexed)",
++		.handler	= ldst_type_pair,
++	}, {
++		.mask		= GENMASK(29, 28) | GENMASK(24, 23),
++		.arm_code	= BIT(29) | BIT(24),
++		.name		= "Load/store register pair(offset)",
++		.handler	= ldst_type_pair,
++	}, {
++		.mask		= GENMASK(29, 28) | GENMASK(24, 23),
++		.arm_code	= BIT(29) | BIT(24) | BIT(23),
++		.name		= "Load/store register pair(pre-indexed)",
++		.handler	= ldst_type_pair,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(29) | BIT(28),
++		.name		= "Load/store register (unscaled immediate)",
++		.handler	= ldst_type_imm,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(29) | BIT(28) | BIT(10),
++		.name		= "Load/store register (immediate post-indexed)",
++		.handler	= ldst_type_imm,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(29) | BIT(28) | BIT(11),
++		.name		= "Load/store register (unprivileged)",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(29) | BIT(28) | BIT(11) | BIT(10),
++		.name		= "Load/store register (immediate pre-indexed)",
++		.handler	= ldst_type_imm,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(29) | BIT(28) | BIT(21),
++		.name		= "Atomic memory operation",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(29) | BIT(28) | BIT(21) | BIT(11),
++		.name		= "Load/store register (register offset)",
++		.handler	= ldst_type_regoff,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | BIT(10),
++		.arm_code	= BIT(29) | BIT(28) | BIT(21) | BIT(10),
++		.name		= "Load/store register (pac)",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24),
++		.arm_code	= BIT(29) | BIT(28) | BIT(24),
++		.name		= "Load/store register (unsigned immediate)",
++		.handler	= ldst_type_imm,
++	},
++};
++
++/* Return 0 on success, return 1 on failure. */
++static int align_ldst_new(u32 insn, struct pt_regs *regs)
++{
++	int i;
++	struct ldst_filter *f;
++
++	for (i = 0; i < ARRAY_SIZE(ldst_filters); i++) {
++		f = (struct ldst_filter *)&ldst_filters[i];
++
++		/* Find the correct hander */
++		if ((f->mask & insn) == f->arm_code) {
++			pr_debug("insn:%x, (%s)\n", insn, f->name);
++			return f->handler(f, insn, regs);
++		}
++	}
++
++	return 1;
++}
+-- 
+2.39.3
+

--- a/v5.4/0006-arm64-fix-the-error-for-instruction-b9400000.patch
+++ b/v5.4/0006-arm64-fix-the-error-for-instruction-b9400000.patch
@@ -1,0 +1,128 @@
+From 28944d469d771258750ce956313583dcb44f08a6 Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Sun, 17 Apr 2022 14:20:09 +0000
+Subject: [PATCH 06/10] arm64: fix the error for instruction :b9400000
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/mm/pcie_unalign_access.c | 97 ++++++++++++++++++++++++++++-
+ 1 file changed, 96 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/mm/pcie_unalign_access.c b/arch/arm64/mm/pcie_unalign_access.c
+index f7c948985296..6dfcd4929a77 100644
+--- a/arch/arm64/mm/pcie_unalign_access.c
++++ b/arch/arm64/mm/pcie_unalign_access.c
+@@ -30,6 +30,101 @@ static int ldst_type_pair(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
+ 		return align_ldst_pair(insn, regs);
+ }
+ 
++static int align_ldst_imm_new(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	bool wback = !(insn & BIT(24)) && !!(insn & BIT(10));
++	bool postindex = wback && !(insn & BIT(11));
++	int scale = size;
++	u64 offset;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	bool is_store;
++	bool is_signed;
++	int regsize;
++	int datasize;
++	u64 address;
++	u64 data;
++
++	if (!(insn & BIT(24))) {
++		u64 uoffset =
++			aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++		offset = sign_extend64(uoffset, 8);
++	} else {
++		offset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_12, insn);
++		offset <<= scale;
++	}
++
++	if ((opc & 0x2) == 0) {
++		/* store or zero-extending load */
++		is_store = !(opc & 0x1);
++		regsize = size == 0x3 ? 64 : 32;
++		is_signed = false;
++	} else {
++		if (size == 0x3) {
++			if (FIELD_GET(GENMASK(11, 10), insn) == 0 && (opc & 0x1) == 0) {
++				/* prefetch */
++				return 0;
++			} else {
++				/* undefined */
++				return 1;
++			}
++		} else {
++			/* sign-extending load */
++			is_store = false;
++			if (size == 0x2 && (opc & 0x1) == 0x1) {
++				/* undefined */
++				return 1;
++			}
++			regsize = (opc & 0x1) == 0x1 ? 32 : 64;
++			is_signed = true;
++		}
++	}
++
++	datasize = 8 << scale;
++
++	if (wback && n == t && n != 31)
++		return 1;
++
++	address = regs_get_register(regs, n << 3);
++
++	if (!postindex)
++		address += offset;
++	printk("{%s] addr:%llx, offset:%llx\n", __func__, address, offset);
++
++	if (is_store) {
++		data = pt_regs_read_reg(regs, t);
++		if (align_store(address, datasize / 8, data))
++			return 1;
++	} else {
++		if (align_load(address, datasize / 8, &data))
++			return 1;
++		if (is_signed) {
++			if (regsize == 32)
++				data = sign_extend32(data, datasize - 1);
++			else
++				data = sign_extend64(data, datasize - 1);
++		}
++		pt_regs_write_reg(regs, t, data);
++	}
++
++	if (wback) {
++		if (postindex)
++			address += offset;
++		if (n == 31)
++			regs->sp = address;
++		else
++			pt_regs_write_reg(regs, n, address);
++	}
++
++	return 0;
++}
++
+ /*
+  * |------+-----+-----+--------+-----+----------------------------------------------|
+  * | op0  | op1 | op2 |    op3 | op4 | Decode group                                 |
+@@ -46,7 +141,7 @@ static int ldst_type_imm(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
+ 	if (insn & BIT(26))
+ 		return align_ldst_imm_simdfp(insn, regs);
+ 	else
+-		return align_ldst_imm(insn, regs);
++		return align_ldst_imm_new(insn, regs);
+ }
+ 
+ /*
+-- 
+2.39.3
+

--- a/v5.4/0007-arm64-add-unprivileged-instruction-support.patch
+++ b/v5.4/0007-arm64-add-unprivileged-instruction-support.patch
@@ -1,0 +1,335 @@
+From 8fa1aab396a66933a5685321cfd3580241e75d07 Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Mon, 9 May 2022 11:20:06 +0000
+Subject: [PATCH 07/10] arm64: add unprivileged instruction support
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/mm/pcie_unalign_access.c | 304 +++++++++++++++++++++++++++-
+ 1 file changed, 303 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/mm/pcie_unalign_access.c b/arch/arm64/mm/pcie_unalign_access.c
+index 6dfcd4929a77..835bbdee8882 100644
+--- a/arch/arm64/mm/pcie_unalign_access.c
++++ b/arch/arm64/mm/pcie_unalign_access.c
+@@ -174,6 +174,308 @@ static int ldst_type_vector_single(struct ldst_filter *f, u32 insn, struct pt_re
+ 	return align_ldst_vector_single(insn, regs);
+ }
+ 
++static int ldst_unpri_sttrb(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	data = pt_regs_read_reg(regs, t);
++
++	/* 3) store it now */
++	return align_store(address, 1, data);
++}
++
++static int ldst_unpri_ldtrb(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data = 0;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	align_load(address, 1, &data);
++	data = sign_extend64(data, 64 - 1);
++
++	/* 3) store it now */
++	pt_regs_write_reg(regs, t, data);
++	return 0;
++}
++
++static int ldst_unpri_ldtrsb_64(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data = 0;
++	int regsize = 64;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	align_load(address, 1, &data);
++
++	/* 64bit or 32 bit? check it with opc[0] */
++	if (insn & BIT(22))
++		regsize = 32;
++	data = sign_extend32(data, regsize - 1);
++
++	/* 3) store it now */
++	pt_regs_write_reg(regs, t, data);
++	return 0;
++}
++
++static int ldst_unpri_sttrh(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	data = pt_regs_read_reg(regs, t);
++
++	/* 3) store it now */
++	return align_store(address, 2, data);
++}
++
++static int ldst_unpri_ldtrh(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data = 0;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	align_load(address, 2, &data);
++	data = sign_extend64(data, 64 - 1);
++
++	/* 3) store it now */
++	pt_regs_write_reg(regs, t, data);
++	return 0;
++}
++
++static int ldst_unpri_ldtrsh(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data = 0;
++	int regsize = 64;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	align_load(address, 2, &data);
++
++	/* 64bit or 32 bit? check it with opc[0] */
++	if (insn & BIT(22))
++		regsize = 32;
++	data = sign_extend32(data, regsize - 1);
++
++	/* 3) store it now */
++	pt_regs_write_reg(regs, t, data);
++	return 0;
++}
++
++static int ldst_unpri_sttr(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data;
++	int scale;
++	int datasize;
++	const u32 SIZE = GENMASK(31, 30);
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	data = pt_regs_read_reg(regs, t);
++
++	/* 3) store it now */
++	scale = FIELD_GET(SIZE, insn);
++	datasize = 8 << scale;
++	return align_store(address, datasize / 8, data);
++}
++
++/* 0xf8400946 */
++static int ldst_unpri_ldtr(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data = 0;
++	int regsize = 64;
++	const u32 SIZE = GENMASK(31, 30);
++	int scale = FIELD_GET(SIZE, insn);
++	int datasize = 8 << scale;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	align_load(address, datasize / 8, &data);
++
++	/* 64bit or 32 bit? */
++	if (scale != 3)
++		regsize = 32;
++
++	/* 3) store it now */
++	pt_regs_write_reg(regs, t, data);
++	return 0;
++}
++
++static int ldst_unpri_ldtrsw(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data = 0;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	align_load(address, 4, &data);
++	data = sign_extend32(data, 64 - 1);
++
++	/* 3) store it now */
++	pt_regs_write_reg(regs, t, data);
++	return 0;
++}
++#define REG_UNPRI_MASK (BIT(31)| BIT(31) | BIT(26) | BIT(22) | BIT(23))
++static const struct ldst_filter ldst_reg_unpri[] = {
++	{
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= 0,
++		.name		= "STTRB",
++		.handler	= ldst_unpri_sttrb,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(22),
++		.name		= "LDTRB",
++		.handler	= ldst_unpri_ldtrb,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(23),
++		.name		= "LDTRSB - 64bit variant",
++		.handler	= ldst_unpri_ldtrsb_64,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(23) | BIT(22),
++		.name		= "LDTRSB - 32bit variant",
++		.handler	= ldst_unpri_ldtrsb_64,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(30),
++		.name		= "STTRH",
++		.handler	= ldst_unpri_sttrh,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(30) | BIT(22),
++		.name		= "LDTRH",
++		.handler	= ldst_unpri_ldtrh,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(30) | BIT(23),
++		.name		= "LDTRSH - 64bit variant",
++		.handler	= ldst_unpri_ldtrsh,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(30) | BIT(23) | BIT(22),
++		.name		= "LDTRSH - 32bit variant",
++		.handler	= ldst_unpri_ldtrsh,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(31),
++		.name		= "STTR - 32bit variant",
++		.handler	= ldst_unpri_sttr,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(31),
++		.name		= "LDTR - 32bit variant",
++		.handler	= ldst_unpri_ldtr,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(31) | BIT(23),
++		.name		= "LDTRSW",
++		.handler	= ldst_unpri_ldtrsw,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(31) | BIT(30),
++		.name		= "STTR - 64bit variant",
++		.handler	= ldst_unpri_sttr,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(31) | BIT(30) | BIT(22),
++		.name		= "LDTR - 64bit variant",
++		.handler	= ldst_unpri_ldtr,
++	},
++};
++
++/* Return 0 on success, return 1 on failure. */
++static int ldst_reg_unprivileged(struct ldst_filter *of, u32 insn, struct pt_regs *regs)
++{
++	int i;
++	struct ldst_filter *f;
++
++	for (i = 0; i < ARRAY_SIZE(ldst_reg_unpri); i++) {
++		f = (struct ldst_filter *)&ldst_reg_unpri[i];
++
++		/* Find the correct hander */
++		if ((f->mask & insn) == f->arm_code) {
++			pr_debug("insn:%x, (%s)\n", insn, f->name);
++			return f->handler(f, insn, regs);
++		}
++	}
++	return 1;
++}
++
+ /* Please see the C4.1.66 */
+ static const struct ldst_filter ldst_filters[] = {
+ 	{
+@@ -281,7 +583,7 @@ static const struct ldst_filter ldst_filters[] = {
+ 		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
+ 		.arm_code	= BIT(29) | BIT(28) | BIT(11),
+ 		.name		= "Load/store register (unprivileged)",
+-		.handler	= ldst_default,
++		.handler	= ldst_reg_unprivileged,
+ 	}, {
+ 		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
+ 		.arm_code	= BIT(29) | BIT(28) | BIT(11) | BIT(10),
+-- 
+2.39.3
+

--- a/v5.4/0008-arm64-pcie-wc-print-out-the-error-log.patch
+++ b/v5.4/0008-arm64-pcie-wc-print-out-the-error-log.patch
@@ -1,0 +1,31 @@
+From 2e479e4d0767cd18958c1ec935d76e921e68e8a0 Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Tue, 4 Jul 2023 14:15:44 +0800
+Subject: [PATCH 08/10] arm64: pcie-wc: print out the error log
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/mm/pcie_unalign_access.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm64/mm/pcie_unalign_access.c b/arch/arm64/mm/pcie_unalign_access.c
+index 835bbdee8882..52475f910154 100644
+--- a/arch/arm64/mm/pcie_unalign_access.c
++++ b/arch/arm64/mm/pcie_unalign_access.c
+@@ -623,8 +623,11 @@ static int align_ldst_new(u32 insn, struct pt_regs *regs)
+ 
+ 		/* Find the correct hander */
+ 		if ((f->mask & insn) == f->arm_code) {
+-			pr_debug("insn:%x, (%s)\n", insn, f->name);
+-			return f->handler(f, insn, regs);
++			int ret = f->handler(f, insn, regs);
++
++			if (ret)
++				pr_info("Failed in handling insn:%x, (%s)\n", insn, f->name);
++			return ret;
+ 		}
+ 	}
+ 
+-- 
+2.39.3
+

--- a/v5.4/0009-pcie-wc-add-support-for-fc2c6b41.patch
+++ b/v5.4/0009-pcie-wc-add-support-for-fc2c6b41.patch
@@ -1,0 +1,119 @@
+From 4f4f8e384b054d96ada4305c34c204a693d7f153 Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Wed, 5 Jul 2023 09:30:43 +0800
+Subject: [PATCH 09/10] pcie-wc: add support for fc2c6b41
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/mm/pcie_unalign_access.c | 81 ++++++++++++++++++++++++++++-
+ 1 file changed, 80 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/mm/pcie_unalign_access.c b/arch/arm64/mm/pcie_unalign_access.c
+index 52475f910154..639c6a48ddee 100644
+--- a/arch/arm64/mm/pcie_unalign_access.c
++++ b/arch/arm64/mm/pcie_unalign_access.c
+@@ -144,6 +144,84 @@ static int ldst_type_imm(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
+ 		return align_ldst_imm_new(insn, regs);
+ }
+ 
++/* handle for fc2c6b41 */
++static int align_ldst_regoff_simdfp_new(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++	const u32 OPTION = GENMASK(15, 13);
++	const u32 S = BIT(12);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	u32 option = FIELD_GET(OPTION, insn);
++	u32 s = FIELD_GET(S, insn);
++	int scale = (opc & 0x2) << 1 | size;
++	int extend_len = (option & 0x1) ? 64 : 32;
++	bool extend_unsigned = !(option & 0x4);
++	int shift = s ? scale : 0;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int m = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RM, insn);
++	bool is_store = !(opc & BIT(0));
++	int datasize;
++	u64 offset;
++	u64 address;
++	u64 data_d0, data_d1;
++
++	/*
++	if ((opc & 0x2) == 0)
++		return 1;
++	*/
++
++	datasize = 8 << scale;
++
++	if (n == t && n != 31)
++		return 1;
++
++	offset = pt_regs_read_reg(regs, m);
++	if (extend_len == 32) {
++		offset &= (u32)~0;
++		if (!extend_unsigned)
++			sign_extend64(offset, 31);
++	}
++	offset <<= shift;
++
++	address = regs_get_register(regs, n << 3) + offset;
++
++	if (is_store) {
++		data_d0 = get_vn_dt(t, 0);
++		if (datasize == 128) {
++			data_d1 = get_vn_dt(t, 1);
++			if (align_store(address, 8, data_d0) ||
++			    align_store(address + 8, 8, data_d1))
++				return 1;
++		} else if (datasize == 64) {
++			/* fc2c6b41 should come here. */
++			if (align_store(address, 8, data_d0))
++				return 1;
++		} else {
++			if (align_store(address, datasize / 8, data_d0))
++				return 1;
++		}
++	} else {
++		if (datasize == 128) {
++			if (align_load(address, 8, &data_d0) ||
++			    align_load(address + 8, 8, &data_d1))
++				return 1;
++		} else {
++			if (align_load(address, datasize / 8, &data_d0))
++				return 1;
++			data_d1 = 0;
++		}
++		set_vn_dt(t, 0, data_d0);
++		set_vn_dt(t, 1, data_d1);
++	}
++
++	return 0;
++}
++
+ /*
+  * |------+-----+-----+--------+-----+---------------------------------------|
+  * | op0  | op1 | op2 |    op3 | op4 |                                       |
+@@ -155,7 +233,7 @@ static int ldst_type_regoff(struct ldst_filter *f, u32 insn, struct pt_regs *reg
+ {
+ 	/* The bit 26 is used for SIMD only, please see the spec */
+ 	if (insn & BIT(26))
+-		return align_ldst_regoff_simdfp(insn, regs);
++		return align_ldst_regoff_simdfp_new(insn, regs);
+ 	else
+ 		return align_ldst_regoff(insn, regs);
+ }
+@@ -625,6 +703,7 @@ static int align_ldst_new(u32 insn, struct pt_regs *regs)
+ 		if ((f->mask & insn) == f->arm_code) {
+ 			int ret = f->handler(f, insn, regs);
+ 
++			pr_debug("handling insn:%x, (%s)\n", insn, f->name);
+ 			if (ret)
+ 				pr_info("Failed in handling insn:%x, (%s)\n", insn, f->name);
+ 			return ret;
+-- 
+2.39.3
+

--- a/v5.4/0010-arm64-pcie-wc-fix-the-typo-for-f8400865.patch
+++ b/v5.4/0010-arm64-pcie-wc-fix-the-typo-for-f8400865.patch
@@ -1,0 +1,26 @@
+From befeeed0c3b9f0833d157e3325c54b9bfc954652 Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Fri, 28 Jul 2023 15:37:35 +0800
+Subject: [PATCH 10/10] arm64: pcie-wc: fix the typo for f8400865
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/mm/pcie_unalign_access.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/mm/pcie_unalign_access.c b/arch/arm64/mm/pcie_unalign_access.c
+index 639c6a48ddee..66826dfe4e9c 100644
+--- a/arch/arm64/mm/pcie_unalign_access.c
++++ b/arch/arm64/mm/pcie_unalign_access.c
+@@ -466,7 +466,7 @@ static int ldst_unpri_ldtrsw(struct ldst_filter *f, u32 insn, struct pt_regs *re
+ 	pt_regs_write_reg(regs, t, data);
+ 	return 0;
+ }
+-#define REG_UNPRI_MASK (BIT(31)| BIT(31) | BIT(26) | BIT(22) | BIT(23))
++#define REG_UNPRI_MASK (BIT(31)| BIT(30) | BIT(26) | BIT(22) | BIT(23))
+ static const struct ldst_filter ldst_reg_unpri[] = {
+ 	{
+ 		.mask		= REG_UNPRI_MASK,
+-- 
+2.39.3
+

--- a/v5.4/0011-Fix-ttbr0-emulation-of-dc-zva.patch
+++ b/v5.4/0011-Fix-ttbr0-emulation-of-dc-zva.patch
@@ -1,0 +1,28 @@
+From a0f5c8659f1a736d64ae037cfc74df50ba83824f Mon Sep 17 00:00:00 2001
+From: D Scott Phillips <scott@os.amperecomputing.com>
+Date: Thu, 20 Mar 2025 07:45:49 -0700
+Subject: [PATCH 1/1] Fix ttbr0 emulation of dc zva
+
+The loop to emulate dc zva in the ttbr0 range was mistakenly not
+updating the address, so not actually clearing all the data in the dc
+zva access, but only the first byte.
+---
+ arch/arm64/mm/fault.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/mm/fault.c b/arch/arm64/mm/fault.c
+index 61d0a5a42718..8061203e5050 100644
+--- a/arch/arm64/mm/fault.c
++++ b/arch/arm64/mm/fault.c
+@@ -736,7 +736,7 @@ static int align_dc_zva(unsigned long addr, struct pt_regs *regs)
+ 	addr &= ~(sz - 1);
+ 	if (is_ttbr0_addr(addr)) {
+ 		for (; sz; sz--) {
+-			if (align_store(addr, 1, 0))
++			if (align_store(addr++, 1, 0))
+ 				return 1;
+ 		}
+ 	} else
+-- 
+2.27.0
+

--- a/v5.4/0012-Fix-load-in-align_ldst_regoff.patch
+++ b/v5.4/0012-Fix-load-in-align_ldst_regoff.patch
@@ -1,0 +1,25 @@
+From 53f5361543660651fa2ed6ac9deabfc98903a225 Mon Sep 17 00:00:00 2001
+From: davidz-ampere <>
+Date: Mon, 24 Mar 2025 22:52:47 -0400
+Subject: [PATCH 1/1] Fix load in align_ldst_regoff
+
+Data is not written back to the register and will cause data mismatch.
+---
+ arch/arm64/mm/fault.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/mm/fault.c b/arch/arm64/mm/fault.c
+index 8061203e5050..e931c47e4cb9 100644
+--- a/arch/arm64/mm/fault.c
++++ b/arch/arm64/mm/fault.c
+@@ -1060,6 +1060,7 @@ static int align_ldst_regoff(u32 insn, struct pt_regs *regs)
+ 			else
+ 				data = sign_extend64(data, datasize - 1);
+ 		}
++		pt_regs_write_reg(regs, t, data);
+ 	}
+ 
+ 	return 0;
+-- 
+2.27.0
+

--- a/v6.2/0001-arm64-Work-around-Ampere-Altra-erratum-82288-PCIE_65.patch
+++ b/v6.2/0001-arm64-Work-around-Ampere-Altra-erratum-82288-PCIE_65.patch
@@ -1,0 +1,178 @@
+From 2c5ebd1859c088fc15d07628835464fdcecc9ba1 Mon Sep 17 00:00:00 2001
+From: D Scott Phillips <scott@os.amperecomputing.com>
+Date: Fri, 13 Nov 2020 08:25:23 -0800
+Subject: [PATCH 01/10] arm64: Work around Ampere Altra erratum #82288 PCIE_65
+
+Altra's PCIe controller may generate incorrect addresses when receiving
+writes from the CPU with a discontiguous set of byte enables. Attempt to
+work around this by handing out Device-nGnRE maps instead of Normal
+Non-cacheable maps for PCIe memory areas.
+
+Signed-off-by: D Scott Phillips <scott@os.amperecomputing.com>
+---
+ Documentation/arm64/silicon-errata.rst |  1 +
+ arch/arm64/Kconfig                     |  9 +++++++++
+ arch/arm64/include/asm/pci.h           |  4 ++++
+ arch/arm64/include/asm/pgtable.h       | 26 +++++++++++++++++++++-----
+ drivers/pci/quirks.c                   |  9 +++++++++
+ mm/ioremap.c                           | 21 ++++++++++++++++++++-
+ 6 files changed, 64 insertions(+), 6 deletions(-)
+
+diff --git a/Documentation/arm64/silicon-errata.rst b/Documentation/arm64/silicon-errata.rst
+index ec5f889d7681..a4aa48bc4e08 100644
+--- a/Documentation/arm64/silicon-errata.rst
++++ b/Documentation/arm64/silicon-errata.rst
+@@ -51,6 +51,7 @@ stable kernels.
+ +================+=================+=================+=============================+
+ | Allwinner      | A64/R18         | UNKNOWN1        | SUN50I_ERRATUM_UNKNOWN1     |
+ +----------------+-----------------+-----------------+-----------------------------+
++| Ampere         | Altra           | #82288          | ALTRA_ERRATUM_82288         |
+ +----------------+-----------------+-----------------+-----------------------------+
+ | ARM            | Cortex-A510     | #2457168        | ARM64_ERRATUM_2457168       |
+ +----------------+-----------------+-----------------+-----------------------------+
+diff --git a/arch/arm64/Kconfig b/arch/arm64/Kconfig
+index ddfd35c86bda..9253d8e64408 100644
+--- a/arch/arm64/Kconfig
++++ b/arch/arm64/Kconfig
+@@ -384,6 +384,15 @@ menu "ARM errata workarounds via the alternatives framework"
+ config ARM64_WORKAROUND_CLEAN_CACHE
+ 	bool
+ 
++config ALTRA_ERRATUM_82288
++	bool "Ampere Altra: 82288: PCIE_65: PCIe Root Port outbound write combining issue"
++	default y
++	help
++	  This option adds an alternative code sequence to work around
++	  Ampere Altra erratum 82288.
++
++	  If unsure, say Y.
++
+ config ARM64_ERRATUM_826319
+ 	bool "Cortex-A53: 826319: System might deadlock if a write cannot complete until read data is accepted"
+ 	default y
+diff --git a/arch/arm64/include/asm/pci.h b/arch/arm64/include/asm/pci.h
+index 016eb6b46dc0..23f855883d9d 100644
+--- a/arch/arm64/include/asm/pci.h
++++ b/arch/arm64/include/asm/pci.h
+@@ -16,7 +16,11 @@
+ #define pcibios_assign_all_busses() \
+ 	(pci_has_flag(PCI_REASSIGN_ALL_BUS))
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++extern bool __read_mostly have_altra_erratum_82288;
++#else
+ #define arch_can_pci_mmap_wc() 1
++#endif
+ 
+ /* Generic PCI */
+ #include <asm-generic/pci.h>
+diff --git a/arch/arm64/include/asm/pgtable.h b/arch/arm64/include/asm/pgtable.h
+index 65e78999c75d..e49603e84c1d 100644
+--- a/arch/arm64/include/asm/pgtable.h
++++ b/arch/arm64/include/asm/pgtable.h
+@@ -229,11 +229,6 @@ static inline pte_t pte_mkyoung(pte_t pte)
+ 	return set_pte_bit(pte, __pgprot(PTE_AF));
+ }
+ 
+-static inline pte_t pte_mkspecial(pte_t pte)
+-{
+-	return set_pte_bit(pte, __pgprot(PTE_SPECIAL));
+-}
+-
+ static inline pte_t pte_mkcont(pte_t pte)
+ {
+ 	pte = set_pte_bit(pte, __pgprot(PTE_CONT));
+@@ -578,6 +573,27 @@ static inline void set_pud_at(struct mm_struct *mm, unsigned long addr,
+ 	__pgprot_modify(prot, PTE_ATTRINDX_MASK, \
+ 			PTE_ATTRINDX(MT_NORMAL_NC) | PTE_PXN | PTE_UXN)
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++extern bool have_altra_erratum_82288;
++#endif
++
++static inline pte_t pte_mkspecial(pte_t pte)
++{
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++	phys_addr_t phys = __pte_to_phys(pte);
++	pgprot_t prot = __pgprot(pte_val(pte) & ~PTE_ADDR_MASK);
++
++	if (unlikely(have_altra_erratum_82288) &&
++	    (phys < 0x80000000 ||
++	     (phys >= 0x200000000000 && phys < 0x400000000000) ||
++	     (phys >= 0x600000000000 && phys < 0x800000000000))) {
++		pte = __pte(__phys_to_pte_val(phys) | pgprot_val(pgprot_device(prot)));
++	}
++#endif
++
++	return set_pte_bit(pte, __pgprot(PTE_SPECIAL));
++}
++
+ #define __HAVE_PHYS_MEM_ACCESS_PROT
+ struct file;
+ extern pgprot_t phys_mem_access_prot(struct file *file, unsigned long pfn,
+diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
+index 8d32a3834688..0cef2fc6841c 100644
+--- a/drivers/pci/quirks.c
++++ b/drivers/pci/quirks.c
+@@ -6028,3 +6028,12 @@ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x9a2d, dpc_log_size);
+ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x9a2f, dpc_log_size);
+ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x9a31, dpc_log_size);
+ #endif
++
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++static void quirk_altra_erratum_82288(struct pci_dev *dev)
++{
++	pr_info_once("Write combining PCI maps disabled due to hardware erratum\n");
++	have_altra_erratum_82288 = true;
++}
++DECLARE_PCI_FIXUP_EARLY(PCI_VENDOR_ID_AMPERE, 0xe100, quirk_altra_erratum_82288);
++#endif
+diff --git a/mm/ioremap.c b/mm/ioremap.c
+index 8652426282cc..3f1f742ed836 100644
+--- a/mm/ioremap.c
++++ b/mm/ioremap.c
+@@ -11,12 +11,26 @@
+ #include <linux/io.h>
+ #include <linux/export.h>
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++bool have_altra_erratum_82288 __read_mostly;
++EXPORT_SYMBOL(have_altra_erratum_82288);
++
++static bool is_altra_pci(phys_addr_t phys_addr, size_t size)
++{
++	phys_addr_t end = phys_addr + size;
++	return (phys_addr < 0x80000000 ||
++		(end > 0x200000000000 && phys_addr < 0x400000000000) ||
++		(end > 0x600000000000 && phys_addr < 0x800000000000));
++}
++#endif
++
+ void __iomem *ioremap_prot(phys_addr_t phys_addr, size_t size,
+ 			   unsigned long prot)
+ {
+ 	unsigned long offset, vaddr;
+ 	phys_addr_t last_addr;
+ 	struct vm_struct *area;
++	pgprot_t pgprot = __pgprot(prot);
+ 
+ 	/* Disallow wrap-around or zero size */
+ 	last_addr = phys_addr + size - 1;
+@@ -38,8 +52,13 @@ void __iomem *ioremap_prot(phys_addr_t phys_addr, size_t size,
+ 	vaddr = (unsigned long)area->addr;
+ 	area->phys_addr = phys_addr;
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++	if (unlikely(have_altra_erratum_82288 && is_altra_pci(phys_addr, size)))
++		pgprot = pgprot_device(pgprot);
++#endif
++
+ 	if (ioremap_page_range(vaddr, vaddr + size, phys_addr,
+-			       __pgprot(prot))) {
++			       pgprot)) {
+ 		free_vm_area(area);
+ 		return NULL;
+ 	}
+-- 
+2.39.3
+

--- a/v6.2/0002-arm64-Add-a-fixup-handler-for-alignment-faults-in-aa.patch
+++ b/v6.2/0002-arm64-Add-a-fixup-handler-for-alignment-faults-in-aa.patch
@@ -1,0 +1,830 @@
+From 7eb2392865b6bb20afefdeb92c1a2ad921d65722 Mon Sep 17 00:00:00 2001
+From: D Scott Phillips <scott@os.amperecomputing.com>
+Date: Thu, 10 Dec 2020 00:07:19 -0800
+Subject: [PATCH 02/10] arm64: Add a fixup handler for alignment faults in
+ aarch64 code
+
+A later patch will hand out Device memory in some cases to code
+which expects a Normal memory type, as an errata workaround.
+Unaligned accesses to Device memory will fault though, so here we
+add a fixup handler to emulate faulting accesses, at a performance
+penalty.
+
+Many of the instructions in the Loads and Stores group are supported,
+but these groups are not handled here:
+
+ * Advanced SIMD load/store multiple structures
+ * Advanced SIMD load/store multiple structures (post-indexed)
+ * Advanced SIMD load/store single structure
+ * Advanced SIMD load/store single structure (post-indexed)
+ * Load/store memory tags
+ * Load/store exclusive
+ * LDAPR/STLR (unscaled immediate)
+ * Load register (literal) [cannot Alignment fault]
+ * Load/store register (unprivileged)
+ * Atomic memory operations
+ * Load/store register (pac)
+
+Instruction implementations are translated from the Exploration tools'
+ASL specifications.
+
+Signed-off-by: D Scott Phillips <scott@os.amperecomputing.com>
+---
+ arch/arm64/include/asm/insn.h |   2 +
+ arch/arm64/mm/fault.c         | 740 ++++++++++++++++++++++++++++++++++
+ 2 files changed, 742 insertions(+)
+
+diff --git a/arch/arm64/include/asm/insn.h b/arch/arm64/include/asm/insn.h
+index aaf1f52fbf3e..1b65d804cff5 100644
+--- a/arch/arm64/include/asm/insn.h
++++ b/arch/arm64/include/asm/insn.h
+@@ -317,6 +317,7 @@ static __always_inline u32 aarch64_insn_get_##abbr##_value(void)	\
+  * "-" means "don't care"
+  */
+ __AARCH64_INSN_FUNCS(class_branch_sys,	0x1c000000, 0x14000000)
++__AARCH64_INSN_FUNCS(class_ld_st,	0x0A000000, 0x08000000)
+ 
+ __AARCH64_INSN_FUNCS(adr,	0x9F000000, 0x10000000)
+ __AARCH64_INSN_FUNCS(adrp,	0x9F000000, 0x90000000)
+@@ -420,6 +421,7 @@ __AARCH64_INSN_FUNCS(sb,	0xFFFFFFFF, 0xD50330FF)
+ __AARCH64_INSN_FUNCS(clrex,	0xFFFFF0FF, 0xD503305F)
+ __AARCH64_INSN_FUNCS(ssbb,	0xFFFFFFFF, 0xD503309F)
+ __AARCH64_INSN_FUNCS(pssbb,	0xFFFFFFFF, 0xD503349F)
++__AARCH64_INSN_FUNCS(dc_zva,	0xFFFFFFE0, 0xD50B7420)
+ 
+ #undef	__AARCH64_INSN_FUNCS
+ 
+diff --git a/arch/arm64/mm/fault.c b/arch/arm64/mm/fault.c
+index 596f46dabe4e..8e3ed357171b 100644
+--- a/arch/arm64/mm/fault.c
++++ b/arch/arm64/mm/fault.c
+@@ -5,6 +5,7 @@
+  * Copyright (C) 1995  Linus Torvalds
+  * Copyright (C) 1995-2004 Russell King
+  * Copyright (C) 2012 ARM Ltd.
++ * Copyright (C) 2020 Ampere Computing LLC
+  */
+ 
+ #include <linux/acpi.h>
+@@ -37,6 +38,7 @@
+ #include <asm/esr.h>
+ #include <asm/kprobes.h>
+ #include <asm/mte.h>
++#include <asm/patching.h>
+ #include <asm/processor.h>
+ #include <asm/sysreg.h>
+ #include <asm/system_misc.h>
+@@ -698,12 +700,750 @@ static int __kprobes do_translation_fault(unsigned long far,
+ 	return 0;
+ }
+ 
++static int copy_from_user_io(void *to, const void __user *from, unsigned long n)
++{
++	const u8 __user *src = from;
++	u8 *dest = to;
++
++	for (; n; n--)
++		if (get_user(*dest++, src++))
++			break;
++	return n;
++}
++
++static int copy_to_user_io(void __user *to, const void *from, unsigned long n)
++{
++	const u8 *src = from;
++	u8 __user *dest = to;
++
++	for (; n; n--)
++		if (put_user(*src++, dest++))
++			break;
++	return n;
++}
++
++static int align_load(unsigned long addr, int sz, u64 *out)
++{
++	union {
++		u8 d8;
++		u16 d16;
++		u32 d32;
++		u64 d64;
++		char c[8];
++	} data;
++
++	if (sz != 1 && sz != 2 && sz != 4 && sz != 8)
++		return 1;
++	if (is_ttbr0_addr(addr)) {
++		if (copy_from_user_io(data.c, (const void __user *)addr, sz))
++			return 1;
++	} else
++		memcpy_fromio(data.c, (const void __iomem *)addr, sz);
++	switch (sz) {
++	case 1:
++		*out = data.d8;
++		break;
++	case 2:
++		*out = data.d16;
++		break;
++	case 4:
++		*out = data.d32;
++		break;
++	case 8:
++		*out = data.d64;
++		break;
++	default:
++		return 1;
++	}
++	return 0;
++}
++
++static int align_store(unsigned long addr, int sz, u64 val)
++{
++	union {
++		u8 d8;
++		u16 d16;
++		u32 d32;
++		u64 d64;
++		char c[8];
++	} data;
++
++	switch (sz) {
++	case 1:
++		data.d8 = val;
++		break;
++	case 2:
++		data.d16 = val;
++		break;
++	case 4:
++		data.d32 = val;
++		break;
++	case 8:
++		data.d64 = val;
++		break;
++	default:
++		return 1;
++	}
++	if (is_ttbr0_addr(addr)) {
++		if (copy_to_user_io((void __user *)addr, data.c, sz))
++			return 1;
++	} else
++		memcpy_toio((void __iomem *)addr, data.c, sz);
++	return 0;
++}
++
++static int align_dc_zva(unsigned long addr, struct pt_regs *regs)
++{
++	int bs = read_cpuid(DCZID_EL0) & 0xf;
++	int sz = 1 << (bs + 2);
++
++	addr &= ~(sz - 1);
++	if (is_ttbr0_addr(addr)) {
++		for (; sz; sz--) {
++			if (align_store(addr, 1, 0))
++				return 1;
++		}
++	} else
++		memset_io((void *)addr, 0, sz);
++	return 0;
++}
++
++static u64 get_vn_dt(int n, int t) {
++	u64 res;
++
++	switch (n) {
++#define V(n)						\
++	case n:						\
++		asm("cbnz %w1, 1f\n\t"			\
++		    "mov %0, v"#n".d[0]\n\t"		\
++		    "b 2f\n\t"				\
++		    "1: mov %0, v"#n".d[1]\n\t"		\
++		    "2:" : "=r" (res) : "r" (t));	\
++		break
++	V( 0); V( 1); V( 2); V( 3); V( 4); V( 5); V( 6); V( 7);
++	V( 8); V( 9); V(10); V(11); V(12); V(13); V(14); V(15);
++	V(16); V(17); V(18); V(19); V(20); V(21); V(22); V(23);
++	V(24); V(25); V(26); V(27); V(28); V(29); V(30); V(31);
++#undef V
++	default:
++		res = 0;
++		break;
++	}
++	return res;
++}
++
++static void set_vn_dt(int n, int t, u64 val) {
++	switch (n) {
++#define V(n)						\
++	case n:						\
++		asm("cbnz %w1, 1f\n\t"			\
++		    "mov v"#n".d[0], %0\n\t"		\
++		    "b 2f\n\t"				\
++		    "1: mov v"#n".d[1], %0\n\t"		\
++		    "2:" :: "r" (val), "r" (t));	\
++		break
++	V( 0); V( 1); V( 2); V( 3); V( 4); V( 5); V( 6); V( 7);
++	V( 8); V( 9); V(10); V(11); V(12); V(13); V(14); V(15);
++	V(16); V(17); V(18); V(19); V(20); V(21); V(22); V(23);
++	V(24); V(25); V(26); V(27); V(28); V(29); V(30); V(31);
++#undef Q
++	default:
++		break;
++	}
++}
++
++static int align_ldst_pair(u32 insn, struct pt_regs *regs)
++{
++	const u32 OPC = GENMASK(31, 30);
++	const u32 L_MASK = BIT(22);
++
++	int opc = FIELD_GET(OPC, insn);
++	int L = FIELD_GET(L_MASK, insn);
++
++	bool wback = !!(insn & BIT(23));
++	bool postindex = !(insn & BIT(24));
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int t2 = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT2, insn);
++	bool is_store = !L;
++	bool is_signed = !!(opc & 1);
++	int scale = 2 + (opc >> 1);
++	int datasize = 8 << scale;
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_7, insn);
++	s64 offset = sign_extend64(uoffset, 6) << scale;
++	u64 address;
++	u64 data1, data2;
++	u64 dbytes;
++
++	if ((is_store && (opc & 1)) || opc == 3)
++		return 1;
++
++	if (wback && (t == n || t2 == n) && n != 31)
++		return 1;
++
++	if (!is_store && t == t2)
++		return 1;
++
++	dbytes = datasize / 8;
++
++	address = regs_get_register(regs, n << 3);
++
++	if (!postindex)
++		address += offset;
++
++	if (is_store) {
++		data1 = pt_regs_read_reg(regs, t);
++		data2 = pt_regs_read_reg(regs, t2);
++		if (align_store(address, dbytes, data1) ||
++		    align_store(address + dbytes, dbytes, data2))
++			return 1;
++	} else {
++		if (align_load(address, dbytes, &data1) ||
++		    align_load(address + dbytes, dbytes, &data2))
++			return 1;
++		if (is_signed) {
++			data1 = sign_extend64(data1, datasize - 1);
++			data2 = sign_extend64(data2, datasize - 1);
++		}
++		pt_regs_write_reg(regs, t, data1);
++		pt_regs_write_reg(regs, t2, data2);
++	}
++
++	if (wback) {
++		if (postindex)
++			address += offset;
++		if (n == 31)
++			regs->sp = address;
++		else
++			pt_regs_write_reg(regs, n, address);
++	}
++
++	return 0;
++}
++
++static int align_ldst_pair_simdfp(u32 insn, struct pt_regs *regs)
++{
++	const u32 OPC = GENMASK(31, 30);
++	const u32 L_MASK = BIT(22);
++
++	int opc = FIELD_GET(OPC, insn);
++	int L = FIELD_GET(L_MASK, insn);
++
++	bool wback = !!(insn & BIT(23));
++	bool postindex = !(insn & BIT(24));
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int t2 = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT2, insn);
++	bool is_store = !L;
++	int scale = 2 + opc;
++	int datasize = 8 << scale;
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_7, insn);
++	s64 offset = sign_extend64(uoffset, 6) << scale;
++	u64 address;
++	u64 data1_d0, data1_d1, data2_d0, data2_d1;
++	u64 dbytes;
++
++	if (opc == 0x3)
++		return 1;
++
++	if (!is_store && t == t2)
++		return 1;
++
++	dbytes = datasize / 8;
++
++	address = regs_get_register(regs, n << 3);
++
++	if (!postindex)
++		address += offset;
++
++	if (is_store) {
++		data1_d0 = get_vn_dt(t, 0);
++		data2_d0 = get_vn_dt(t2, 0);
++		if (datasize == 128) {
++			data1_d1 = get_vn_dt(t, 1);
++			data2_d1 = get_vn_dt(t2, 1);
++			if (align_store(address, 8, data1_d0) ||
++			    align_store(address + 8, 8, data1_d1) ||
++			    align_store(address + 16, 8, data2_d0) ||
++			    align_store(address + 24, 8, data2_d1))
++				return 1;
++		} else {
++			if (align_store(address, dbytes, data1_d0) ||
++			    align_store(address + dbytes, dbytes, data2_d0))
++				return 1;
++		}
++	} else {
++		if (datasize == 128) {
++			if (align_load(address, 8, &data1_d0) ||
++			    align_load(address + 8, 8, &data1_d1) ||
++			    align_load(address + 16, 8, &data2_d0) ||
++			    align_load(address + 24, 8, &data2_d1))
++				return 1;
++		} else {
++			if (align_load(address, dbytes, &data1_d0) ||
++			    align_load(address + dbytes, dbytes, &data2_d0))
++				return 1;
++			data1_d1 = data2_d1 = 0;
++		}
++		set_vn_dt(t, 0, data1_d0);
++		set_vn_dt(t, 1, data1_d1);
++		set_vn_dt(t2, 0, data2_d0);
++		set_vn_dt(t2, 1, data2_d1);
++	}
++
++	if (wback) {
++		if (postindex)
++			address += offset;
++		if (n == 31)
++			regs->sp = address;
++		else
++			pt_regs_write_reg(regs, n, address);
++	}
++
++	return 0;
++}
++
++static int align_ldst_regoff(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++	const u32 OPTION = GENMASK(15, 13);
++	const u32 S = BIT(12);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	u32 option = FIELD_GET(OPTION, insn);
++	u32 s = FIELD_GET(S, insn);
++	int scale = size;
++	int extend_len = (option & 0x1) ? 64 : 32;
++	bool extend_unsigned = !(option & 0x4);
++	int shift = s ? scale : 0;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int m = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RM, insn);
++	bool is_store;
++	bool is_signed;
++	int regsize;
++	int datasize;
++	u64 offset;
++	u64 address;
++	u64 data;
++
++	if ((opc & 0x2) == 0) {
++		/* store or zero-extending load */
++		is_store = !(opc & 0x1);
++		regsize = size == 0x3 ? 64 : 32;
++		is_signed = false;
++	} else {
++		if (size == 0x3) {
++			if ((opc & 0x1) == 0) {
++				/* prefetch */
++				return 0;
++			} else {
++				/* undefined */
++				return 1;
++			}
++		} else {
++			/* sign-extending load */
++			is_store = false;
++			if (size == 0x2 && (opc & 0x1) == 0x1) {
++				/* undefined */
++				return 1;
++			}
++			regsize = (opc & 0x1) == 0x1 ? 32 : 64;
++			is_signed = true;
++		}
++	}
++
++	datasize = 8 << scale;
++
++	if (n == t && n != 31)
++		return 1;
++
++	offset = pt_regs_read_reg(regs, m);
++	if (extend_len == 32) {
++		offset &= (u32)~0;
++		if (!extend_unsigned)
++			sign_extend64(offset, 31);
++	}
++	offset <<= shift;
++
++	address = regs_get_register(regs, n << 3) + offset;
++
++	if (is_store) {
++		data = pt_regs_read_reg(regs, t);
++		if (align_store(address, datasize / 8, data))
++			return 1;
++	} else {
++		if (align_load(address, datasize / 8, &data))
++			return 1;
++		if (is_signed) {
++			if (regsize == 32)
++				data = sign_extend32(data, datasize - 1);
++			else
++				data = sign_extend64(data, datasize - 1);
++		}
++	}
++
++	return 0;
++}
++
++static int align_ldst_regoff_simdfp(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++	const u32 OPTION = GENMASK(15, 13);
++	const u32 S = BIT(12);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	u32 option = FIELD_GET(OPTION, insn);
++	u32 s = FIELD_GET(S, insn);
++	int scale = (opc & 0x2) << 1 | size;
++	int extend_len = (option & 0x1) ? 64 : 32;
++	bool extend_unsigned = !(option & 0x4);
++	int shift = s ? scale : 0;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int m = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RM, insn);
++	bool is_store = !(opc & BIT(0));
++	int datasize;
++	u64 offset;
++	u64 address;
++	u64 data_d0, data_d1;
++
++	if ((opc & 0x2) == 0)
++		return 1;
++
++	datasize = 8 << scale;
++
++	if (n == t && n != 31)
++		return 1;
++
++	offset = pt_regs_read_reg(regs, m);
++	if (extend_len == 32) {
++		offset &= (u32)~0;
++		if (!extend_unsigned)
++			sign_extend64(offset, 31);
++	}
++	offset <<= shift;
++
++	address = regs_get_register(regs, n << 3) + offset;
++
++	if (is_store) {
++		data_d0 = get_vn_dt(t, 0);
++		if (datasize == 128) {
++			data_d1 = get_vn_dt(t, 1);
++			if (align_store(address, 8, data_d0) ||
++			    align_store(address + 8, 8, data_d1))
++				return 1;
++		} else {
++			if (align_store(address, datasize / 8, data_d0))
++				return 1;
++		}
++	} else {
++		if (datasize == 128) {
++			if (align_load(address, 8, &data_d0) ||
++			    align_load(address + 8, 8, &data_d1))
++				return 1;
++		} else {
++			if (align_load(address, datasize / 8, &data_d0))
++				return 1;
++			data_d1 = 0;
++		}
++		set_vn_dt(t, 0, data_d0);
++		set_vn_dt(t, 1, data_d1);
++	}
++
++	return 0;
++}
++
++static int align_ldst_imm(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	bool wback = !(insn & BIT(24)) && !!(insn & BIT(10));
++	bool postindex = wback && !(insn & BIT(11));
++	int scale = size;
++	u64 offset;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	bool is_store;
++	bool is_signed;
++	int regsize;
++	int datasize;
++	u64 address;
++	u64 data;
++
++	if (!(insn & BIT(24))) {
++		u64 uoffset =
++			aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++		offset = sign_extend64(uoffset, 8);
++	} else {
++		offset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_12, insn);
++		offset <<= scale;
++	}
++
++	if ((opc & 0x2) == 0) {
++		/* store or zero-extending load */
++		is_store = !(opc & 0x1);
++		regsize = size == 0x3 ? 64 : 32;
++		is_signed = false;
++	} else {
++		if (size == 0x3) {
++			if (FIELD_GET(GENMASK(11, 10), insn) == 0 && (opc & 0x1) == 0) {
++				/* prefetch */
++				return 0;
++			} else {
++				/* undefined */
++				return 1;
++			}
++		} else {
++			/* sign-extending load */
++			is_store = false;
++			if (size == 0x2 && (opc & 0x1) == 0x1) {
++				/* undefined */
++				return 1;
++			}
++			regsize = (opc & 0x1) == 0x1 ? 32 : 64;
++			is_signed = true;
++		}
++	}
++
++	datasize = 8 << scale;
++
++	if (n == t && n != 31)
++		return 1;
++
++	address = regs_get_register(regs, n << 3);
++
++	if (!postindex)
++		address += offset;
++
++	if (is_store) {
++		data = pt_regs_read_reg(regs, t);
++		if (align_store(address, datasize / 8, data))
++			return 1;
++	} else {
++		if (align_load(address, datasize / 8, &data))
++			return 1;
++		if (is_signed) {
++			if (regsize == 32)
++				data = sign_extend32(data, datasize - 1);
++			else
++				data = sign_extend64(data, datasize - 1);
++		}
++		pt_regs_write_reg(regs, t, data);
++	}
++
++	if (wback) {
++		if (postindex)
++			address += offset;
++		if (n == 31)
++			regs->sp = address;
++		else
++			pt_regs_write_reg(regs, n, address);
++	}
++
++	return 0;
++}
++
++static int align_ldst_imm_simdfp(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	bool wback = !(insn & BIT(24)) && !!(insn & BIT(10));
++	bool postindex = wback && !(insn & BIT(11));
++	int scale = (opc & 0x2) << 1 | size;
++	u64 offset;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	bool is_store = !(opc & BIT(0)) ;
++	int datasize;
++	u64 address;
++	u64 data_d0, data_d1;
++
++	if (scale > 4)
++		return 1;
++
++	if (!(insn & BIT(24))) {
++		u64 uoffset =
++			aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++		offset = sign_extend64(uoffset, 8);
++	} else {
++		offset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_12, insn);
++		offset <<= scale;
++	}
++
++	datasize = 8 << scale;
++
++	address = regs_get_register(regs, n << 3);
++
++	if (!postindex)
++		address += offset;
++
++	if (is_store) {
++		data_d0 = get_vn_dt(t, 0);
++		if (datasize == 128) {
++			data_d1 = get_vn_dt(t, 1);
++			if (align_store(address, 8, data_d0) ||
++			    align_store(address + 8, 8, data_d1))
++				return 1;
++		} else {
++			if (align_store(address, datasize / 8, data_d0))
++				return 1;
++		}
++	} else {
++		if (datasize == 128) {
++			if (align_load(address, 8, &data_d0) ||
++			    align_load(address + 8, 8, &data_d1))
++				return 1;
++		} else {
++			if (align_load(address, datasize / 8, &data_d0))
++				return 1;
++			data_d1 = 0;
++		}
++		set_vn_dt(t, 0, data_d0);
++		set_vn_dt(t, 1, data_d1);
++	}
++
++	if (wback) {
++		if (postindex)
++			address += offset;
++		if (n == 31)
++			regs->sp = address;
++		else
++			pt_regs_write_reg(regs, n, address);
++	}
++
++	return 0;
++}
++
++static int align_ldst(u32 insn, struct pt_regs *regs)
++{
++	const u32 op0 = FIELD_GET(GENMASK(31, 28), insn);
++	const u32 op1 = FIELD_GET(BIT(26), insn);
++	const u32 op2 = FIELD_GET(GENMASK(24, 23), insn);
++	const u32 op3 = FIELD_GET(GENMASK(21, 16), insn);
++	const u32 op4 = FIELD_GET(GENMASK(11, 10), insn);
++
++	if ((op0 & 0x3) == 0x2) {
++		/*
++		 * |------+-----+-----+-----+-----+-----------------------------------------|
++		 * | op0  | op1 | op2 | op3 | op4 | Decode group                            |
++		 * |------+-----+-----+-----+-----+-----------------------------------------|
++		 * | xx10 | -   |  00 | -   | -   | Load/store no-allocate pair (offset)    |
++		 * | xx10 | -   |  01 | -   | -   | Load/store register pair (post-indexed) |
++		 * | xx10 | -   |  10 | -   | -   | Load/store register pair (offset)       |
++		 * | xx10 | -   |  11 | -   | -   | Load/store register pair (pre-indexed)  |
++		 * |------+-----+-----+-----+-----+-----------------------------------------|
++		 */
++
++		if (op1 == 0) { /* V == 0 */
++			/* general */
++			return align_ldst_pair(insn, regs);
++		} else {
++			/* simdfp */
++			return align_ldst_pair_simdfp(insn, regs);
++		}
++	} else if ((op0 & 0x3) == 0x3 &&
++		   (((op2 & 0x2) == 0 && (op3 & 0x20) == 0 && op4 != 0x2) ||
++		    ((op2 & 0x2) == 0x2))) {
++		/*
++		 * |------+-----+-----+--------+-----+----------------------------------------------|
++		 * | op0  | op1 | op2 |    op3 | op4 | Decode group                                 |
++		 * |------+-----+-----+--------+-----+----------------------------------------------|
++		 * | xx11 | -   |  0x | 0xxxxx |  00 | Load/store register (unscaled immediate)     |
++		 * | xx11 | -   |  0x | 0xxxxx |  01 | Load/store register (immediate post-indexed) |
++		 * | xx11 | -   |  0x | 0xxxxx |  11 | Load/store register (immediate pre-indexed)  |
++		 * | xx11 | -   |  1x |      - |   - | Load/store register (unsigned immediate)     |
++		 * |------+-----+-----+--------+-----+----------------------------------------------|
++		 */
++
++		if (op1 == 0) {  /* V == 0 */
++			/* general */
++			return align_ldst_imm(insn, regs);
++		} else {
++			/* simdfp */
++			return align_ldst_imm_simdfp(insn, regs);
++		}
++	} else if ((op0 & 0x3) == 0x3 && (op2 & 0x2) == 0 &&
++		   (op3 & 0x20) == 0x20 && op4 == 0x2) {
++		/*
++		 * |------+-----+-----+--------+-----+---------------------------------------|
++		 * | op0  | op1 | op2 |    op3 | op4 |                                       |
++		 * |------+-----+-----+--------+-----+---------------------------------------|
++		 * | xx11 | -   |  0x | 1xxxxx |  10 | Load/store register (register offset) |
++		 * |------+-----+-----+--------+-----+---------------------------------------|
++		 */
++		if (op1 == 0) { /* V == 0 */
++			/* general */
++			return align_ldst_regoff(insn, regs);
++		} else {
++			/* simdfp */
++			return align_ldst_regoff_simdfp(insn, regs);
++		}
++	} else
++		return 1;
++}
++
++static int fixup_alignment(unsigned long addr, unsigned int esr,
++			   struct pt_regs *regs)
++{
++	u32 insn;
++	int res;
++
++	if (user_mode(regs)) {
++		__le32 insn_le;
++
++		if (!is_ttbr0_addr(addr))
++			return 1;
++
++		if (get_user(insn_le,
++			     (__le32 __user *)instruction_pointer(regs)))
++			return 1;
++		insn = le32_to_cpu(insn_le);
++	} else {
++		if (aarch64_insn_read((void *)instruction_pointer(regs), &insn))
++			return 1;
++	}
++
++	if (aarch64_insn_is_dc_zva(insn)) {
++		res = align_dc_zva(addr, regs);
++	} else if (aarch64_insn_is_class_ld_st(insn)) {
++		res = align_ldst(insn, regs);
++	} else
++		res = 1;
++
++	if (!res) {
++		instruction_pointer_set(regs, instruction_pointer(regs) + 4);
++	}
++	return res;
++}
++
+ static int do_alignment_fault(unsigned long far, unsigned long esr,
+ 			      struct pt_regs *regs)
+ {
+ 	if (IS_ENABLED(CONFIG_COMPAT_ALIGNMENT_FIXUPS) &&
+ 	    compat_user_mode(regs))
+ 		return do_compat_alignment_fixup(far, regs);
++
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++	if (!fixup_alignment(far, esr, regs))
++		return 0;
++#endif
+ 	do_bad_area(far, esr, regs);
+ 	return 0;
+ }
+-- 
+2.39.3
+

--- a/v6.2/0003-arm64-Add-alignment-faults-handler-for-Advanced-SIMD.patch
+++ b/v6.2/0003-arm64-Add-alignment-faults-handler-for-Advanced-SIMD.patch
@@ -1,0 +1,206 @@
+From 6a478ef771e0a62d32d07be32ee67317b4c1295a Mon Sep 17 00:00:00 2001
+From: D Scott Phillips <scott@os.amperecomputing.com>
+Date: Thu, 3 Mar 2022 15:43:08 +0800
+Subject: [PATCH 03/10] arm64: Add alignment faults handler for Advanced SIMD
+ load/store single
+
+Signed-off-by: D Scott Phillips <scott@os.amperecomputing.com>
+---
+ arch/arm64/mm/fault.c | 160 +++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 159 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/mm/fault.c b/arch/arm64/mm/fault.c
+index 8e3ed357171b..160a47af090e 100644
+--- a/arch/arm64/mm/fault.c
++++ b/arch/arm64/mm/fault.c
+@@ -804,7 +804,7 @@ static int align_dc_zva(unsigned long addr, struct pt_regs *regs)
+ 				return 1;
+ 		}
+ 	} else
+-		memset_io((void *)addr, 0, sz);
++		memset_io((void __iomem *)addr, 0, sz);
+ 	return 0;
+ }
+ 
+@@ -852,6 +852,44 @@ static void set_vn_dt(int n, int t, u64 val) {
+ 	}
+ }
+ 
++static u64 replicate64(u64 val, int bits)
++{
++	switch (bits) {
++	case 8:
++		val = (val << 8) | (val & 0xff);
++		fallthrough;
++	case 16:
++		val = (val << 16) | (val & 0xffff);
++		fallthrough;
++	case 32:
++		val = (val << 32) | (val & 0xffffffff);
++		break;
++	default:
++		break;
++	}
++	return val;
++}
++
++static u64 elem_get(u64 hi, u64 lo, int index, int esize)
++{
++	int shift = index * esize;
++	u64 mask = GENMASK(esize - 1, 0);
++	if (shift < 64)
++		return (lo >> shift) & mask;
++	else
++		return (hi >> (shift - 64)) & mask;
++}
++
++static void elem_set(u64 *hi, u64 *lo, int index, int esize, u64 val)
++{
++	int shift = index * esize;
++	u64 mask = GENMASK(esize - 1, 0);
++	if (shift < 64)
++		*lo = (*lo & ~(mask << shift)) | ((val & mask) << shift);
++	else
++		*hi = (*hi & ~(mask << (shift - 64))) | ((val & mask) << (shift - 64));
++}
++
+ static int align_ldst_pair(u32 insn, struct pt_regs *regs)
+ {
+ 	const u32 OPC = GENMASK(31, 30);
+@@ -1331,6 +1369,114 @@ static int align_ldst_imm_simdfp(u32 insn, struct pt_regs *regs)
+ 	return 0;
+ }
+ 
++static int align_ldst_vector_single(u32 insn, struct pt_regs *regs)
++{
++	const u32 Q_MASK = BIT(30);
++	const u32 L_MASK = BIT(22);
++	const u32 R_MASK = BIT(21);
++	const u32 OPCODE = GENMASK(15, 13);
++	const u32 S_MASK = BIT(12);
++	const u32 SIZE = GENMASK(11, 10);
++	u32 Q = FIELD_GET(Q_MASK, insn);
++	u32 L = FIELD_GET(L_MASK, insn);
++	u32 R = FIELD_GET(R_MASK, insn);
++	u32 opcode = FIELD_GET(OPCODE, insn);
++	u32 S = FIELD_GET(S_MASK, insn);
++	u32 size = FIELD_GET(SIZE, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int m = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RM, insn);
++	bool wback = !!(insn & BIT(23));
++	int init_scale = opcode >> 1;
++	int scale = init_scale;
++	int selem = (((opcode & 1) << 1) | R) + 1;
++	bool replicate = false;
++	int index;
++	int datasize;
++	int esize;
++	u64 address;
++	u64 offs;
++	u64 rval_d0, rval_d1;
++	u64 element;
++	int ebytes;
++	int s;
++	u64 data;
++	switch (scale) {
++	case 3:
++		if (!L || S)
++			return 1;
++		scale = size;
++		replicate = true;
++		break;
++	case 0:
++		index = (Q << 3) | (S << 2) | size;
++		break;
++	case 1:
++		if (size & 1)
++			return 1;
++		index = (Q << 2) | (S << 1) | (size >> 1);
++		break;
++	case 2:
++		if (size & 2)
++			return 1;
++		if (!(size & 1))
++			index = (Q << 1) | S;
++		else {
++			if (S)
++				return 1;
++			index = Q;
++			scale = 3;
++		}
++		break;
++	}
++	datasize = Q ? 128 : 64;
++	esize = 8 << scale;
++	ebytes = esize / 8;
++	address = regs_get_register(regs, n << 3);
++	offs = 0;
++	if (replicate) {
++		for (s = 0; s < selem; s++) {
++			if (align_load(address + offs, ebytes, &element))
++				return 1;
++			data = replicate64(element, esize);
++			set_vn_dt(t, 0, data);
++			if (datasize == 128)
++				set_vn_dt(t, 1, data);
++			else
++				set_vn_dt(t, 1, 0);
++			offs += ebytes;
++			t = (t + 1) & 31;
++		}
++	} else {
++		for (s = 0; s < selem; s++) {
++			rval_d0 = get_vn_dt(t, 0);
++			rval_d1 = get_vn_dt(t, 1);
++			if (L) {
++				if (align_load(address + offs, ebytes, &data))
++					return 1;
++				elem_set(&rval_d1, &rval_d0, index, esize, data);
++				set_vn_dt(t, 0, rval_d0);
++				set_vn_dt(t, 1, rval_d1);
++			} else {
++				data = elem_get(rval_d1, rval_d0, index, esize);
++				if (align_store(address + offs, ebytes, data))
++					return 1;
++			}
++			offs += ebytes;
++			t = (t + 1) & 31;
++		}
++	}
++	if (wback) {
++		if (m != 31)
++			offs = regs_get_register(regs, m << 3);
++		if (n == 31)
++			regs->sp = address + offs;
++		else
++			pt_regs_write_reg(regs, n, address + offs);
++	}
++	return 0;
++}
++
+ static int align_ldst(u32 insn, struct pt_regs *regs)
+ {
+ 	const u32 op0 = FIELD_GET(GENMASK(31, 28), insn);
+@@ -1395,6 +1541,18 @@ static int align_ldst(u32 insn, struct pt_regs *regs)
+ 			/* simdfp */
+ 			return align_ldst_regoff_simdfp(insn, regs);
+ 		}
++	} else if ((op0 & 0xb) == 0 && op1 == 1 &&
++		   ((op2 == 2 && ((op3 & 0x1f) == 0)) || op2 == 3)) {
++		/*
++		 * |------+-----+-----+--------+-----+-------------------------------------------|
++		 * | op0  | op1 | op2 |    op3 | op4 |                                           |
++		 * |------+-----+-----+--------+-----+-------------------------------------------|
++		 * | 0x00 |   1 |  10 | x00000 |   - | Advanced SIMD load/store single structure |
++		 * | 0x00 |   1 |  11 |      - |   - | Advanced SIMD load/store single structure |
++		 * |      |     |     |        |     |   (post-indexed)                          |
++		 * |------+-----+-----+--------+-----+-------------------------------------------|
++		 */
++		return align_ldst_vector_single(insn, regs);
+ 	} else
+ 		return 1;
+ }
+-- 
+2.39.3
+

--- a/v6.2/0004-arm64-remove-the-hardcode-about-PCI-address-checking.patch
+++ b/v6.2/0004-arm64-remove-the-hardcode-about-PCI-address-checking.patch
@@ -1,0 +1,151 @@
+From 64ecd4272987ca0ca943fd479f6ec2756123adba Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Fri, 8 Apr 2022 20:43:33 +0000
+Subject: [PATCH 04/10] arm64: remove the hardcode about PCI address checking
+
+Copy name in find_next_iomem_res() for checking the PCI
+address.
+
+Remove the bool check for VM which does not has the ALTRA pci device.
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/include/asm/pgtable.h |  7 +++---
+ include/linux/pci.h              |  4 +++
+ kernel/resource.c                | 43 ++++++++++++++++++++++++++++++++
+ mm/ioremap.c                     | 12 +++------
+ 4 files changed, 53 insertions(+), 13 deletions(-)
+
+diff --git a/arch/arm64/include/asm/pgtable.h b/arch/arm64/include/asm/pgtable.h
+index e49603e84c1d..f10b3b7ce04c 100644
+--- a/arch/arm64/include/asm/pgtable.h
++++ b/arch/arm64/include/asm/pgtable.h
+@@ -575,6 +575,8 @@ static inline void set_pud_at(struct mm_struct *mm, unsigned long addr,
+ 
+ #ifdef CONFIG_ALTRA_ERRATUM_82288
+ extern bool have_altra_erratum_82288;
++extern bool range_is_pci(phys_addr_t, size_t);
++
+ #endif
+ 
+ static inline pte_t pte_mkspecial(pte_t pte)
+@@ -583,10 +585,7 @@ static inline pte_t pte_mkspecial(pte_t pte)
+ 	phys_addr_t phys = __pte_to_phys(pte);
+ 	pgprot_t prot = __pgprot(pte_val(pte) & ~PTE_ADDR_MASK);
+ 
+-	if (unlikely(have_altra_erratum_82288) &&
+-	    (phys < 0x80000000 ||
+-	     (phys >= 0x200000000000 && phys < 0x400000000000) ||
+-	     (phys >= 0x600000000000 && phys < 0x800000000000))) {
++	if (range_is_pci(phys, PAGE_SIZE)) {
+ 		pte = __pte(__phys_to_pte_val(phys) | pgprot_val(pgprot_device(prot)));
+ 	}
+ #endif
+diff --git a/include/linux/pci.h b/include/linux/pci.h
+index 7e8e8633ad90..3f0f657d45b6 100644
+--- a/include/linux/pci.h
++++ b/include/linux/pci.h
+@@ -2560,4 +2560,8 @@ void pci_ims_free_irq(struct pci_dev *pdev, struct msi_map map);
+ 	WARN_ONCE(condition, "%s %s: " fmt, \
+ 		  dev_driver_string(&(pdev)->dev), pci_name(pdev), ##arg)
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++extern bool range_is_pci(phys_addr_t phys_addr, size_t size);
++#endif
++
+ #endif /* LINUX_PCI_H */
+diff --git a/kernel/resource.c b/kernel/resource.c
+index b1763b2fd7ef..2e65afe5c137 100644
+--- a/kernel/resource.c
++++ b/kernel/resource.c
+@@ -364,6 +364,7 @@ static int find_next_iomem_res(resource_size_t start, resource_size_t end,
+ 			.flags = p->flags,
+ 			.desc = p->desc,
+ 			.parent = p->parent,
++			.name = p->name,
+ 		};
+ 	}
+ 
+@@ -489,6 +490,48 @@ int __weak page_is_ram(unsigned long pfn)
+ }
+ EXPORT_SYMBOL_GPL(page_is_ram);
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++/* Return 0 on success, else return 1 */
++static int pci_addr_check(struct resource *r, void *p)
++{
++	if (!r->name)
++		return 1;
++
++	if (strlen(r->name) <= 2)
++		return 1;
++
++	if (memcmp(r->name, "PCI", 3))
++		return 1;
++
++	/* Success */
++	return 0;
++}
++
++bool range_is_pci(phys_addr_t phys_addr, size_t size)
++{
++	u64 start, end;
++	int ret;
++
++	start = phys_addr;
++	end = phys_addr + size;
++
++	/* Check the 32bit */
++	ret = walk_iomem_res_desc(IORES_DESC_NONE, IORESOURCE_MEM,
++			start, end, NULL, pci_addr_check);
++	if (!ret)
++		return true;
++
++	/* Check the 64bit */
++	ret = walk_iomem_res_desc(IORES_DESC_NONE, IORESOURCE_MEM_64,
++			start, end, NULL, pci_addr_check);
++	if (!ret)
++		return true;
++
++	return false;
++}
++EXPORT_SYMBOL_GPL(range_is_pci);
++#endif
++
+ static int __region_intersects(struct resource *parent, resource_size_t start,
+ 			       size_t size, unsigned long flags,
+ 			       unsigned long desc)
+diff --git a/mm/ioremap.c b/mm/ioremap.c
+index 3f1f742ed836..545c8043b31b 100644
+--- a/mm/ioremap.c
++++ b/mm/ioremap.c
+@@ -14,14 +14,6 @@
+ #ifdef CONFIG_ALTRA_ERRATUM_82288
+ bool have_altra_erratum_82288 __read_mostly;
+ EXPORT_SYMBOL(have_altra_erratum_82288);
+-
+-static bool is_altra_pci(phys_addr_t phys_addr, size_t size)
+-{
+-	phys_addr_t end = phys_addr + size;
+-	return (phys_addr < 0x80000000 ||
+-		(end > 0x200000000000 && phys_addr < 0x400000000000) ||
+-		(end > 0x600000000000 && phys_addr < 0x800000000000));
+-}
+ #endif
+ 
+ void __iomem *ioremap_prot(phys_addr_t phys_addr, size_t size,
+@@ -53,8 +45,10 @@ void __iomem *ioremap_prot(phys_addr_t phys_addr, size_t size,
+ 	area->phys_addr = phys_addr;
+ 
+ #ifdef CONFIG_ALTRA_ERRATUM_82288
+-	if (unlikely(have_altra_erratum_82288 && is_altra_pci(phys_addr, size)))
++	if ((pgprot_val(pgprot) != pgprot_val(pgprot_device(pgprot))) &&
++			range_is_pci(phys_addr, size)) {
+ 		pgprot = pgprot_device(pgprot);
++	}
+ #endif
+ 
+ 	if (ioremap_page_range(vaddr, vaddr + size, phys_addr,
+-- 
+2.39.3
+

--- a/v6.2/0005-arm64-Add-new-code-for-unaligned-pcie-access.patch
+++ b/v6.2/0005-arm64-Add-new-code-for-unaligned-pcie-access.patch
@@ -1,0 +1,304 @@
+From a0f192286525ca912b347b0588b12bbc591dd923 Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Tue, 12 Apr 2022 12:09:54 +0000
+Subject: [PATCH 05/10] arm64: Add new code for unaligned pcie access
+
+Add a new function align_ldst_new to handle the rest instructions
+if align_ldst() fails.
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/mm/fault.c               |  13 ++
+ arch/arm64/mm/pcie_unalign_access.c | 235 ++++++++++++++++++++++++++++
+ 2 files changed, 248 insertions(+)
+ create mode 100644 arch/arm64/mm/pcie_unalign_access.c
+
+diff --git a/arch/arm64/mm/fault.c b/arch/arm64/mm/fault.c
+index 160a47af090e..52df98c7623a 100644
+--- a/arch/arm64/mm/fault.c
++++ b/arch/arm64/mm/fault.c
+@@ -1557,11 +1557,14 @@ static int align_ldst(u32 insn, struct pt_regs *regs)
+ 		return 1;
+ }
+ 
++#include "pcie_unalign_access.c"
++
+ static int fixup_alignment(unsigned long addr, unsigned int esr,
+ 			   struct pt_regs *regs)
+ {
+ 	u32 insn;
+ 	int res;
++	struct pt_regs t = *regs;
+ 
+ 	if (user_mode(regs)) {
+ 		__le32 insn_le;
+@@ -1578,15 +1581,25 @@ static int fixup_alignment(unsigned long addr, unsigned int esr,
+ 			return 1;
+ 	}
+ 
++	pr_debug("start to handle insn:%x\n", insn);
+ 	if (aarch64_insn_is_dc_zva(insn)) {
+ 		res = align_dc_zva(addr, regs);
+ 	} else if (aarch64_insn_is_class_ld_st(insn)) {
+ 		res = align_ldst(insn, regs);
++		if (res) {
++			/* Try it again, copy back if we succeed */
++			res = align_ldst_new(insn, &t);
++			if (!res)
++				*regs = t;
++		}
+ 	} else
+ 		res = 1;
+ 
+ 	if (!res) {
+ 		instruction_pointer_set(regs, instruction_pointer(regs) + 4);
++	} else {
++		pr_err("cannot handle insn:0x%08X \n", insn);
++		dump_stack();
+ 	}
+ 	return res;
+ }
+diff --git a/arch/arm64/mm/pcie_unalign_access.c b/arch/arm64/mm/pcie_unalign_access.c
+new file mode 100644
+index 000000000000..f7c948985296
+--- /dev/null
++++ b/arch/arm64/mm/pcie_unalign_access.c
+@@ -0,0 +1,235 @@
++struct ldst_filter {
++	u32 mask;
++	u32 arm_code;
++	char *name;
++	int (*handler)(struct ldst_filter *, u32, struct pt_regs*);
++};
++
++static int ldst_default(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	pr_alert("instruction :%x(%s) is not implemented.\n", insn, f->name);
++	return 1;
++}
++
++/*
++ * |------+-----+-----+-----+-----+-----------------------------------------|
++ * | op0  | op1 | op2 | op3 | op4 | Decode group                            |
++ * |------+-----+-----+-----+-----+-----------------------------------------|
++ * | xx10 | -   |  00 | -   | -   | Load/store no-allocate pair (offset)    |
++ * | xx10 | -   |  01 | -   | -   | Load/store register pair (post-indexed) |
++ * | xx10 | -   |  10 | -   | -   | Load/store register pair (offset)       |
++ * | xx10 | -   |  11 | -   | -   | Load/store register pair (pre-indexed)  |
++ * |------+-----+-----+-----+-----+-----------------------------------------|
++ */
++static int ldst_type_pair(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	/* The bit 26 is used for SIMD only, please see the spec */
++	if (insn & BIT(26))
++		return align_ldst_pair_simdfp(insn, regs);
++	else
++		return align_ldst_pair(insn, regs);
++}
++
++/*
++ * |------+-----+-----+--------+-----+----------------------------------------------|
++ * | op0  | op1 | op2 |    op3 | op4 | Decode group                                 |
++ * |------+-----+-----+--------+-----+----------------------------------------------|
++ * | xx11 | -   |  0x | 0xxxxx |  00 | Load/store register (unscaled immediate)     |
++ * | xx11 | -   |  0x | 0xxxxx |  01 | Load/store register (immediate post-indexed) |
++ * | xx11 | -   |  0x | 0xxxxx |  11 | Load/store register (immediate pre-indexed)  |
++ * | xx11 | -   |  1x |      - |   - | Load/store register (unsigned immediate)     |
++ * |------+-----+-----+--------+-----+----------------------------------------------|
++ */
++static int ldst_type_imm(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	/* The bit 26 is used for SIMD only, please see the spec */
++	if (insn & BIT(26))
++		return align_ldst_imm_simdfp(insn, regs);
++	else
++		return align_ldst_imm(insn, regs);
++}
++
++/*
++ * |------+-----+-----+--------+-----+---------------------------------------|
++ * | op0  | op1 | op2 |    op3 | op4 |                                       |
++ * |------+-----+-----+--------+-----+---------------------------------------|
++ * | xx11 | -   |  0x | 1xxxxx |  10 | Load/store register (register offset) |
++ * |------+-----+-----+--------+-----+---------------------------------------|
++ */
++static int ldst_type_regoff(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	/* The bit 26 is used for SIMD only, please see the spec */
++	if (insn & BIT(26))
++		return align_ldst_regoff_simdfp(insn, regs);
++	else
++		return align_ldst_regoff(insn, regs);
++}
++
++/*
++ * |------+-----+-----+--------+-----+-------------------------------------------|
++ * | op0  | op1 | op2 |    op3 | op4 |                                           |
++ * |------+-----+-----+--------+-----+-------------------------------------------|
++ * | 0x00 |   1 |  10 | x00000 |   - | Advanced SIMD load/store single structure |
++ * | 0x00 |   1 |  11 |      - |   - | Advanced SIMD load/store single structure |
++ * |      |     |     |        |     |   (post-indexed)                          |
++ * |------+-----+-----+--------+-----+-------------------------------------------|
++ */
++static int ldst_type_vector_single(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	return align_ldst_vector_single(insn, regs);
++}
++
++/* Please see the C4.1.66 */
++static const struct ldst_filter ldst_filters[] = {
++	{
++		.mask		= BIT(31) | GENMASK(29, 28) | BIT(26)
++					| GENMASK(24, 23) | BIT(21),
++		.arm_code	= BIT(21),
++		.name		= "Compare and swap pair",
++		.handler	= ldst_default,
++	}, {
++		.mask		= BIT(31) | GENMASK(29, 28) | BIT(26)
++					| GENMASK(24, 23) | GENMASK(21, 16),
++		.arm_code	= BIT(26),
++		.name		= "Advanced SIMD load/store multiple structures",
++		.handler	= ldst_default,
++	}, {
++		.mask		= BIT(31) | GENMASK(29, 28) | BIT(26)
++					| GENMASK(24, 23) | BIT(21),
++		.arm_code	= BIT(26) | BIT(23),
++		.name		= "Advanced SIMD load/store multiple structures(post-indexed)",
++		.handler	= ldst_default,
++	}, {
++		.mask		= BIT(31) | GENMASK(29, 28) | BIT(26)
++					| GENMASK(24, 23) | GENMASK(20, 16),
++		.arm_code	= BIT(26) | BIT(24),
++		.name		= "Advanced SIMD load/store single structures",
++		.handler	= ldst_type_vector_single,
++	}, {
++		.mask		= BIT(31) | GENMASK(29, 28) | BIT(26) | GENMASK(24, 23),
++		.arm_code	= BIT(26) | BIT(24) | BIT(23),
++		.name		= "Advanced SIMD load/store single structures(post-indexed)",
++		.handler	= ldst_type_vector_single,
++	}, {
++		.mask		= GENMASK(31, 28) | BIT(26) | BIT(24) | BIT(21),
++		.arm_code	= BIT(31) | BIT(30) | BIT(28) | BIT(24) | BIT(21),
++		.name		= "Load/store memory tags",
++		.handler	= ldst_default,
++	}, {
++		.mask		= BIT(31) | GENMASK(29, 28) | BIT(26)
++					| GENMASK(24, 23) | BIT(21),
++		.arm_code	= BIT(31) | BIT(21),
++		.name		= "Load/store exclusive pair",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(26) | GENMASK(24, 23) | BIT(21),
++		.arm_code	= 0,
++		.name		= "Load/store exclusive register",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(26) | GENMASK(24, 23) | BIT(21),
++		.arm_code	= BIT(23),
++		.name		= "Load/store ordered",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(26) | GENMASK(24, 23) | BIT(21),
++		.arm_code	= BIT(23) | BIT(21),
++		.name		= "Compare and swap",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(26) | BIT(24) | BIT(21) |
++					GENMASK(11, 10),
++		.arm_code	= BIT(28) | BIT(24),
++		.name		= "LDAPR/STLR(unscaled immediate)",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24),
++		.arm_code	= BIT(28),
++		.name		= "Load register(literal)",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(28) | BIT(10),
++		.name		= "Memory Copy and Memory Set",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | GENMASK(24, 23),
++		.arm_code	= BIT(29),
++		.name		= "Load/store no-allocate pair(offset)",
++		.handler	= ldst_type_pair,
++	}, {
++		.mask		= GENMASK(29, 28) | GENMASK(24, 23),
++		.arm_code	= BIT(29) | BIT(23),
++		.name		= "Load/store register pair(post-indexed)",
++		.handler	= ldst_type_pair,
++	}, {
++		.mask		= GENMASK(29, 28) | GENMASK(24, 23),
++		.arm_code	= BIT(29) | BIT(24),
++		.name		= "Load/store register pair(offset)",
++		.handler	= ldst_type_pair,
++	}, {
++		.mask		= GENMASK(29, 28) | GENMASK(24, 23),
++		.arm_code	= BIT(29) | BIT(24) | BIT(23),
++		.name		= "Load/store register pair(pre-indexed)",
++		.handler	= ldst_type_pair,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(29) | BIT(28),
++		.name		= "Load/store register (unscaled immediate)",
++		.handler	= ldst_type_imm,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(29) | BIT(28) | BIT(10),
++		.name		= "Load/store register (immediate post-indexed)",
++		.handler	= ldst_type_imm,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(29) | BIT(28) | BIT(11),
++		.name		= "Load/store register (unprivileged)",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(29) | BIT(28) | BIT(11) | BIT(10),
++		.name		= "Load/store register (immediate pre-indexed)",
++		.handler	= ldst_type_imm,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(29) | BIT(28) | BIT(21),
++		.name		= "Atomic memory operation",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
++		.arm_code	= BIT(29) | BIT(28) | BIT(21) | BIT(11),
++		.name		= "Load/store register (register offset)",
++		.handler	= ldst_type_regoff,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | BIT(10),
++		.arm_code	= BIT(29) | BIT(28) | BIT(21) | BIT(10),
++		.name		= "Load/store register (pac)",
++		.handler	= ldst_default,
++	}, {
++		.mask		= GENMASK(29, 28) | BIT(24),
++		.arm_code	= BIT(29) | BIT(28) | BIT(24),
++		.name		= "Load/store register (unsigned immediate)",
++		.handler	= ldst_type_imm,
++	},
++};
++
++/* Return 0 on success, return 1 on failure. */
++static int align_ldst_new(u32 insn, struct pt_regs *regs)
++{
++	int i;
++	struct ldst_filter *f;
++
++	for (i = 0; i < ARRAY_SIZE(ldst_filters); i++) {
++		f = (struct ldst_filter *)&ldst_filters[i];
++
++		/* Find the correct hander */
++		if ((f->mask & insn) == f->arm_code) {
++			pr_debug("insn:%x, (%s)\n", insn, f->name);
++			return f->handler(f, insn, regs);
++		}
++	}
++
++	return 1;
++}
+-- 
+2.39.3
+

--- a/v6.2/0006-arm64-fix-the-error-for-instruction-b9400000.patch
+++ b/v6.2/0006-arm64-fix-the-error-for-instruction-b9400000.patch
@@ -1,0 +1,128 @@
+From ce35f69602678d3d60906a5dae0196cbb85ca052 Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Sun, 17 Apr 2022 14:20:09 +0000
+Subject: [PATCH 06/10] arm64: fix the error for instruction :b9400000
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/mm/pcie_unalign_access.c | 97 ++++++++++++++++++++++++++++-
+ 1 file changed, 96 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/mm/pcie_unalign_access.c b/arch/arm64/mm/pcie_unalign_access.c
+index f7c948985296..6dfcd4929a77 100644
+--- a/arch/arm64/mm/pcie_unalign_access.c
++++ b/arch/arm64/mm/pcie_unalign_access.c
+@@ -30,6 +30,101 @@ static int ldst_type_pair(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
+ 		return align_ldst_pair(insn, regs);
+ }
+ 
++static int align_ldst_imm_new(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	bool wback = !(insn & BIT(24)) && !!(insn & BIT(10));
++	bool postindex = wback && !(insn & BIT(11));
++	int scale = size;
++	u64 offset;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	bool is_store;
++	bool is_signed;
++	int regsize;
++	int datasize;
++	u64 address;
++	u64 data;
++
++	if (!(insn & BIT(24))) {
++		u64 uoffset =
++			aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++		offset = sign_extend64(uoffset, 8);
++	} else {
++		offset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_12, insn);
++		offset <<= scale;
++	}
++
++	if ((opc & 0x2) == 0) {
++		/* store or zero-extending load */
++		is_store = !(opc & 0x1);
++		regsize = size == 0x3 ? 64 : 32;
++		is_signed = false;
++	} else {
++		if (size == 0x3) {
++			if (FIELD_GET(GENMASK(11, 10), insn) == 0 && (opc & 0x1) == 0) {
++				/* prefetch */
++				return 0;
++			} else {
++				/* undefined */
++				return 1;
++			}
++		} else {
++			/* sign-extending load */
++			is_store = false;
++			if (size == 0x2 && (opc & 0x1) == 0x1) {
++				/* undefined */
++				return 1;
++			}
++			regsize = (opc & 0x1) == 0x1 ? 32 : 64;
++			is_signed = true;
++		}
++	}
++
++	datasize = 8 << scale;
++
++	if (wback && n == t && n != 31)
++		return 1;
++
++	address = regs_get_register(regs, n << 3);
++
++	if (!postindex)
++		address += offset;
++	printk("{%s] addr:%llx, offset:%llx\n", __func__, address, offset);
++
++	if (is_store) {
++		data = pt_regs_read_reg(regs, t);
++		if (align_store(address, datasize / 8, data))
++			return 1;
++	} else {
++		if (align_load(address, datasize / 8, &data))
++			return 1;
++		if (is_signed) {
++			if (regsize == 32)
++				data = sign_extend32(data, datasize - 1);
++			else
++				data = sign_extend64(data, datasize - 1);
++		}
++		pt_regs_write_reg(regs, t, data);
++	}
++
++	if (wback) {
++		if (postindex)
++			address += offset;
++		if (n == 31)
++			regs->sp = address;
++		else
++			pt_regs_write_reg(regs, n, address);
++	}
++
++	return 0;
++}
++
+ /*
+  * |------+-----+-----+--------+-----+----------------------------------------------|
+  * | op0  | op1 | op2 |    op3 | op4 | Decode group                                 |
+@@ -46,7 +141,7 @@ static int ldst_type_imm(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
+ 	if (insn & BIT(26))
+ 		return align_ldst_imm_simdfp(insn, regs);
+ 	else
+-		return align_ldst_imm(insn, regs);
++		return align_ldst_imm_new(insn, regs);
+ }
+ 
+ /*
+-- 
+2.39.3
+

--- a/v6.2/0007-arm64-add-unprivileged-instruction-support.patch
+++ b/v6.2/0007-arm64-add-unprivileged-instruction-support.patch
@@ -1,0 +1,335 @@
+From c93d020c30a9544ecbe6de98a86f74371a3a591a Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Mon, 9 May 2022 11:20:06 +0000
+Subject: [PATCH 07/10] arm64: add unprivileged instruction support
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/mm/pcie_unalign_access.c | 304 +++++++++++++++++++++++++++-
+ 1 file changed, 303 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/mm/pcie_unalign_access.c b/arch/arm64/mm/pcie_unalign_access.c
+index 6dfcd4929a77..835bbdee8882 100644
+--- a/arch/arm64/mm/pcie_unalign_access.c
++++ b/arch/arm64/mm/pcie_unalign_access.c
+@@ -174,6 +174,308 @@ static int ldst_type_vector_single(struct ldst_filter *f, u32 insn, struct pt_re
+ 	return align_ldst_vector_single(insn, regs);
+ }
+ 
++static int ldst_unpri_sttrb(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	data = pt_regs_read_reg(regs, t);
++
++	/* 3) store it now */
++	return align_store(address, 1, data);
++}
++
++static int ldst_unpri_ldtrb(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data = 0;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	align_load(address, 1, &data);
++	data = sign_extend64(data, 64 - 1);
++
++	/* 3) store it now */
++	pt_regs_write_reg(regs, t, data);
++	return 0;
++}
++
++static int ldst_unpri_ldtrsb_64(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data = 0;
++	int regsize = 64;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	align_load(address, 1, &data);
++
++	/* 64bit or 32 bit? check it with opc[0] */
++	if (insn & BIT(22))
++		regsize = 32;
++	data = sign_extend32(data, regsize - 1);
++
++	/* 3) store it now */
++	pt_regs_write_reg(regs, t, data);
++	return 0;
++}
++
++static int ldst_unpri_sttrh(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	data = pt_regs_read_reg(regs, t);
++
++	/* 3) store it now */
++	return align_store(address, 2, data);
++}
++
++static int ldst_unpri_ldtrh(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data = 0;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	align_load(address, 2, &data);
++	data = sign_extend64(data, 64 - 1);
++
++	/* 3) store it now */
++	pt_regs_write_reg(regs, t, data);
++	return 0;
++}
++
++static int ldst_unpri_ldtrsh(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data = 0;
++	int regsize = 64;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	align_load(address, 2, &data);
++
++	/* 64bit or 32 bit? check it with opc[0] */
++	if (insn & BIT(22))
++		regsize = 32;
++	data = sign_extend32(data, regsize - 1);
++
++	/* 3) store it now */
++	pt_regs_write_reg(regs, t, data);
++	return 0;
++}
++
++static int ldst_unpri_sttr(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data;
++	int scale;
++	int datasize;
++	const u32 SIZE = GENMASK(31, 30);
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	data = pt_regs_read_reg(regs, t);
++
++	/* 3) store it now */
++	scale = FIELD_GET(SIZE, insn);
++	datasize = 8 << scale;
++	return align_store(address, datasize / 8, data);
++}
++
++/* 0xf8400946 */
++static int ldst_unpri_ldtr(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data = 0;
++	int regsize = 64;
++	const u32 SIZE = GENMASK(31, 30);
++	int scale = FIELD_GET(SIZE, insn);
++	int datasize = 8 << scale;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	align_load(address, datasize / 8, &data);
++
++	/* 64bit or 32 bit? */
++	if (scale != 3)
++		regsize = 32;
++
++	/* 3) store it now */
++	pt_regs_write_reg(regs, t, data);
++	return 0;
++}
++
++static int ldst_unpri_ldtrsw(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
++{
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++	u64 address;
++	u64 data = 0;
++
++	/* 1) Get the address */
++	address = regs_get_register(regs, n << 3);
++	address += offset;
++
++	/* 2) Get the data */
++	align_load(address, 4, &data);
++	data = sign_extend32(data, 64 - 1);
++
++	/* 3) store it now */
++	pt_regs_write_reg(regs, t, data);
++	return 0;
++}
++#define REG_UNPRI_MASK (BIT(31)| BIT(31) | BIT(26) | BIT(22) | BIT(23))
++static const struct ldst_filter ldst_reg_unpri[] = {
++	{
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= 0,
++		.name		= "STTRB",
++		.handler	= ldst_unpri_sttrb,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(22),
++		.name		= "LDTRB",
++		.handler	= ldst_unpri_ldtrb,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(23),
++		.name		= "LDTRSB - 64bit variant",
++		.handler	= ldst_unpri_ldtrsb_64,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(23) | BIT(22),
++		.name		= "LDTRSB - 32bit variant",
++		.handler	= ldst_unpri_ldtrsb_64,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(30),
++		.name		= "STTRH",
++		.handler	= ldst_unpri_sttrh,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(30) | BIT(22),
++		.name		= "LDTRH",
++		.handler	= ldst_unpri_ldtrh,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(30) | BIT(23),
++		.name		= "LDTRSH - 64bit variant",
++		.handler	= ldst_unpri_ldtrsh,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(30) | BIT(23) | BIT(22),
++		.name		= "LDTRSH - 32bit variant",
++		.handler	= ldst_unpri_ldtrsh,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(31),
++		.name		= "STTR - 32bit variant",
++		.handler	= ldst_unpri_sttr,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(31),
++		.name		= "LDTR - 32bit variant",
++		.handler	= ldst_unpri_ldtr,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(31) | BIT(23),
++		.name		= "LDTRSW",
++		.handler	= ldst_unpri_ldtrsw,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(31) | BIT(30),
++		.name		= "STTR - 64bit variant",
++		.handler	= ldst_unpri_sttr,
++	}, {
++		.mask		= REG_UNPRI_MASK,
++		.arm_code	= BIT(31) | BIT(30) | BIT(22),
++		.name		= "LDTR - 64bit variant",
++		.handler	= ldst_unpri_ldtr,
++	},
++};
++
++/* Return 0 on success, return 1 on failure. */
++static int ldst_reg_unprivileged(struct ldst_filter *of, u32 insn, struct pt_regs *regs)
++{
++	int i;
++	struct ldst_filter *f;
++
++	for (i = 0; i < ARRAY_SIZE(ldst_reg_unpri); i++) {
++		f = (struct ldst_filter *)&ldst_reg_unpri[i];
++
++		/* Find the correct hander */
++		if ((f->mask & insn) == f->arm_code) {
++			pr_debug("insn:%x, (%s)\n", insn, f->name);
++			return f->handler(f, insn, regs);
++		}
++	}
++	return 1;
++}
++
+ /* Please see the C4.1.66 */
+ static const struct ldst_filter ldst_filters[] = {
+ 	{
+@@ -281,7 +583,7 @@ static const struct ldst_filter ldst_filters[] = {
+ 		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
+ 		.arm_code	= BIT(29) | BIT(28) | BIT(11),
+ 		.name		= "Load/store register (unprivileged)",
+-		.handler	= ldst_default,
++		.handler	= ldst_reg_unprivileged,
+ 	}, {
+ 		.mask		= GENMASK(29, 28) | BIT(24) | BIT(21) | GENMASK(11, 10),
+ 		.arm_code	= BIT(29) | BIT(28) | BIT(11) | BIT(10),
+-- 
+2.39.3
+

--- a/v6.2/0008-arm64-pcie-wc-print-out-the-error-log.patch
+++ b/v6.2/0008-arm64-pcie-wc-print-out-the-error-log.patch
@@ -1,0 +1,31 @@
+From 20e81c0de588aba72e86735e76772c6cf0381eb8 Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Tue, 4 Jul 2023 14:15:44 +0800
+Subject: [PATCH 08/10] arm64: pcie-wc: print out the error log
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/mm/pcie_unalign_access.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm64/mm/pcie_unalign_access.c b/arch/arm64/mm/pcie_unalign_access.c
+index 835bbdee8882..52475f910154 100644
+--- a/arch/arm64/mm/pcie_unalign_access.c
++++ b/arch/arm64/mm/pcie_unalign_access.c
+@@ -623,8 +623,11 @@ static int align_ldst_new(u32 insn, struct pt_regs *regs)
+ 
+ 		/* Find the correct hander */
+ 		if ((f->mask & insn) == f->arm_code) {
+-			pr_debug("insn:%x, (%s)\n", insn, f->name);
+-			return f->handler(f, insn, regs);
++			int ret = f->handler(f, insn, regs);
++
++			if (ret)
++				pr_info("Failed in handling insn:%x, (%s)\n", insn, f->name);
++			return ret;
+ 		}
+ 	}
+ 
+-- 
+2.39.3
+

--- a/v6.2/0009-pcie-wc-add-support-for-fc2c6b41.patch
+++ b/v6.2/0009-pcie-wc-add-support-for-fc2c6b41.patch
@@ -1,0 +1,119 @@
+From 707bebd85e0dba66ca0af5896b837389bba93bb2 Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Wed, 5 Jul 2023 09:30:43 +0800
+Subject: [PATCH 09/10] pcie-wc: add support for fc2c6b41
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/mm/pcie_unalign_access.c | 81 ++++++++++++++++++++++++++++-
+ 1 file changed, 80 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/mm/pcie_unalign_access.c b/arch/arm64/mm/pcie_unalign_access.c
+index 52475f910154..639c6a48ddee 100644
+--- a/arch/arm64/mm/pcie_unalign_access.c
++++ b/arch/arm64/mm/pcie_unalign_access.c
+@@ -144,6 +144,84 @@ static int ldst_type_imm(struct ldst_filter *f, u32 insn, struct pt_regs *regs)
+ 		return align_ldst_imm_new(insn, regs);
+ }
+ 
++/* handle for fc2c6b41 */
++static int align_ldst_regoff_simdfp_new(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++	const u32 OPTION = GENMASK(15, 13);
++	const u32 S = BIT(12);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	u32 option = FIELD_GET(OPTION, insn);
++	u32 s = FIELD_GET(S, insn);
++	int scale = (opc & 0x2) << 1 | size;
++	int extend_len = (option & 0x1) ? 64 : 32;
++	bool extend_unsigned = !(option & 0x4);
++	int shift = s ? scale : 0;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int m = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RM, insn);
++	bool is_store = !(opc & BIT(0));
++	int datasize;
++	u64 offset;
++	u64 address;
++	u64 data_d0, data_d1;
++
++	/*
++	if ((opc & 0x2) == 0)
++		return 1;
++	*/
++
++	datasize = 8 << scale;
++
++	if (n == t && n != 31)
++		return 1;
++
++	offset = pt_regs_read_reg(regs, m);
++	if (extend_len == 32) {
++		offset &= (u32)~0;
++		if (!extend_unsigned)
++			sign_extend64(offset, 31);
++	}
++	offset <<= shift;
++
++	address = regs_get_register(regs, n << 3) + offset;
++
++	if (is_store) {
++		data_d0 = get_vn_dt(t, 0);
++		if (datasize == 128) {
++			data_d1 = get_vn_dt(t, 1);
++			if (align_store(address, 8, data_d0) ||
++			    align_store(address + 8, 8, data_d1))
++				return 1;
++		} else if (datasize == 64) {
++			/* fc2c6b41 should come here. */
++			if (align_store(address, 8, data_d0))
++				return 1;
++		} else {
++			if (align_store(address, datasize / 8, data_d0))
++				return 1;
++		}
++	} else {
++		if (datasize == 128) {
++			if (align_load(address, 8, &data_d0) ||
++			    align_load(address + 8, 8, &data_d1))
++				return 1;
++		} else {
++			if (align_load(address, datasize / 8, &data_d0))
++				return 1;
++			data_d1 = 0;
++		}
++		set_vn_dt(t, 0, data_d0);
++		set_vn_dt(t, 1, data_d1);
++	}
++
++	return 0;
++}
++
+ /*
+  * |------+-----+-----+--------+-----+---------------------------------------|
+  * | op0  | op1 | op2 |    op3 | op4 |                                       |
+@@ -155,7 +233,7 @@ static int ldst_type_regoff(struct ldst_filter *f, u32 insn, struct pt_regs *reg
+ {
+ 	/* The bit 26 is used for SIMD only, please see the spec */
+ 	if (insn & BIT(26))
+-		return align_ldst_regoff_simdfp(insn, regs);
++		return align_ldst_regoff_simdfp_new(insn, regs);
+ 	else
+ 		return align_ldst_regoff(insn, regs);
+ }
+@@ -625,6 +703,7 @@ static int align_ldst_new(u32 insn, struct pt_regs *regs)
+ 		if ((f->mask & insn) == f->arm_code) {
+ 			int ret = f->handler(f, insn, regs);
+ 
++			pr_debug("handling insn:%x, (%s)\n", insn, f->name);
+ 			if (ret)
+ 				pr_info("Failed in handling insn:%x, (%s)\n", insn, f->name);
+ 			return ret;
+-- 
+2.39.3
+

--- a/v6.2/0010-arm64-pcie-wc-fix-the-typo-for-f8400865.patch
+++ b/v6.2/0010-arm64-pcie-wc-fix-the-typo-for-f8400865.patch
@@ -1,0 +1,26 @@
+From 06e416e4ee6a2b61029c75d468f033f6f6cbf124 Mon Sep 17 00:00:00 2001
+From: Huang Shijie <shijie@os.amperecomputing.com>
+Date: Fri, 28 Jul 2023 15:37:35 +0800
+Subject: [PATCH 10/10] arm64: pcie-wc: fix the typo for f8400865
+
+Signed-off-by: Huang Shijie <shijie@os.amperecomputing.com>
+---
+ arch/arm64/mm/pcie_unalign_access.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/mm/pcie_unalign_access.c b/arch/arm64/mm/pcie_unalign_access.c
+index 639c6a48ddee..66826dfe4e9c 100644
+--- a/arch/arm64/mm/pcie_unalign_access.c
++++ b/arch/arm64/mm/pcie_unalign_access.c
+@@ -466,7 +466,7 @@ static int ldst_unpri_ldtrsw(struct ldst_filter *f, u32 insn, struct pt_regs *re
+ 	pt_regs_write_reg(regs, t, data);
+ 	return 0;
+ }
+-#define REG_UNPRI_MASK (BIT(31)| BIT(31) | BIT(26) | BIT(22) | BIT(23))
++#define REG_UNPRI_MASK (BIT(31)| BIT(30) | BIT(26) | BIT(22) | BIT(23))
+ static const struct ldst_filter ldst_reg_unpri[] = {
+ 	{
+ 		.mask		= REG_UNPRI_MASK,
+-- 
+2.39.3
+

--- a/v6.2/0011-Fix-ttbr0-emulation-of-dc-zva.patch
+++ b/v6.2/0011-Fix-ttbr0-emulation-of-dc-zva.patch
@@ -1,0 +1,28 @@
+From a4f5598538e3114bf8854410500e32f57833015a Mon Sep 17 00:00:00 2001
+From: D Scott Phillips <scott@os.amperecomputing.com>
+Date: Thu, 20 Mar 2025 07:45:49 -0700
+Subject: [PATCH 1/1] Fix ttbr0 emulation of dc zva
+
+The loop to emulate dc zva in the ttbr0 range was mistakenly not
+updating the address, so not actually clearing all the data in the dc
+zva access, but only the first byte.
+---
+ arch/arm64/mm/fault.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/mm/fault.c b/arch/arm64/mm/fault.c
+index 52df98c7623a..2c69bc8d39be 100644
+--- a/arch/arm64/mm/fault.c
++++ b/arch/arm64/mm/fault.c
+@@ -800,7 +800,7 @@ static int align_dc_zva(unsigned long addr, struct pt_regs *regs)
+ 	addr &= ~(sz - 1);
+ 	if (is_ttbr0_addr(addr)) {
+ 		for (; sz; sz--) {
+-			if (align_store(addr, 1, 0))
++			if (align_store(addr++, 1, 0))
+ 				return 1;
+ 		}
+ 	} else
+-- 
+2.27.0
+

--- a/v6.2/0012-Fix-load-in-align_ldst_regoff.patch
+++ b/v6.2/0012-Fix-load-in-align_ldst_regoff.patch
@@ -1,0 +1,25 @@
+From 2a12b0263d47a4e75f1bc334ae2a47a7a380f6ca Mon Sep 17 00:00:00 2001
+From: davidz-ampere <>
+Date: Mon, 24 Mar 2025 22:52:47 -0400
+Subject: [PATCH 1/1] Fix load in align_ldst_regoff
+
+Data is not written back to the register and will cause data mismatch.
+---
+ arch/arm64/mm/fault.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/mm/fault.c b/arch/arm64/mm/fault.c
+index 2c69bc8d39be..ba54930523a8 100644
+--- a/arch/arm64/mm/fault.c
++++ b/arch/arm64/mm/fault.c
+@@ -1124,6 +1124,7 @@ static int align_ldst_regoff(u32 insn, struct pt_regs *regs)
+ 			else
+ 				data = sign_extend64(data, datasize - 1);
+ 		}
++		pt_regs_write_reg(regs, t, data);
+ 	}
+ 
+ 	return 0;
+-- 
+2.27.0
+


### PR DESCRIPTION
Add patches for kernel v5.4, v5.10, v5.15, v6.2:

0001-arm64-Work-around-Ampere-Altra-erratum-82288-PCIE_65.patch
0002-arm64-Add-a-fixup-handler-for-alignment-faults-in-aa.patch
0003-arm64-Add-alignment-faults-handler-for-Advanced-SIMD.patch
0004-arm64-remove-the-hardcode-about-PCI-address-checking.patch
0005-arm64-Add-new-code-for-unaligned-pcie-access.patch
0006-arm64-fix-the-error-for-instruction-b9400000.patch
0007-arm64-add-unprivileged-instruction-support.patch
0008-arm64-pcie-wc-print-out-the-error-log.patch
0009-pcie-wc-add-support-for-fc2c6b41.patch
0010-arm64-pcie-wc-fix-the-typo-for-f8400865.patch
0011-Fix-ttbr0-emulation-of-dc-zva.patch
0012-Fix-load-in-align_ldst_regoff.patch
