### PR TITLE
Rebase for v6.19.7

### DIFF
--- a/v6.19.7/0001-ampere-arm64-Add-a-fixup-handler-for-alignment-fault.patch
+++ b/v6.19.7/0001-ampere-arm64-Add-a-fixup-handler-for-alignment-fault.patch
@@ -1,0 +1,1 @@
+../v6.15/0001-ampere-arm64-Add-a-fixup-handler-for-alignment-fault.patch

--- a/v6.19.7/0002-ampere-arm64-Work-around-Ampere-Altra-erratum-82288-.patch
+++ b/v6.19.7/0002-ampere-arm64-Work-around-Ampere-Altra-erratum-82288-.patch
@@ -1,0 +1,207 @@
+From 1b53d0be267773731107d01dfe3d36764ce8ff0f Mon Sep 17 00:00:00 2001
+From: D Scott Phillips <scott@os.amperecomputing.com>
+Date: Tue, 13 Feb 2024 11:08:06 -0800
+Subject: [PATCH 2/2] ampere/arm64: Work around Ampere Altra erratum #82288
+ PCIE_65
+
+Altra's PCIe controller may generate incorrect addresses when receiving
+writes from the CPU with a discontiguous set of byte enables. Attempt to
+work around this by handing out Device-nGnRE maps instead of Normal
+Non-cacheable maps for PCIe memory areas.
+
+Signed-off-by: D Scott Phillips <scott@os.amperecomputing.com>
+---
+ Documentation/arch/arm64/silicon-errata.rst |  2 ++
+ arch/arm64/Kconfig                          | 21 +++++++++++++++
+ arch/arm64/include/asm/pci.h                |  6 +++++
+ arch/arm64/include/asm/pgtable.h            | 26 ++++++++++++++----
+ arch/arm64/mm/ioremap.c                     | 30 +++++++++++++++++++++
+ drivers/pci/quirks.c                        | 11 ++++++++
+ 6 files changed, 91 insertions(+), 5 deletions(-)
+
+diff --git a/Documentation/arch/arm64/silicon-errata.rst b/Documentation/arch/arm64/silicon-errata.rst
+index a7ec57060..ff763cd3d 100644
+--- a/Documentation/arch/arm64/silicon-errata.rst
++++ b/Documentation/arch/arm64/silicon-errata.rst
+@@ -53,6 +53,8 @@ stable kernels.
+ | Allwinner      | A64/R18         | UNKNOWN1        | SUN50I_ERRATUM_UNKNOWN1     |
+ +----------------+-----------------+-----------------+-----------------------------+
+ +----------------+-----------------+-----------------+-----------------------------+
++| Ampere         | Altra           | #82288          | ALTRA_ERRATUM_82288         |
+++----------------+-----------------+-----------------+-----------------------------+
+ | Ampere         | AmpereOne       | AC03_CPU_38     | AMPERE_ERRATUM_AC03_CPU_38  |
+ +----------------+-----------------+-----------------+-----------------------------+
+ | Ampere         | AmpereOne AC04  | AC04_CPU_10     | AMPERE_ERRATUM_AC03_CPU_38  |
+diff --git a/arch/arm64/Kconfig b/arch/arm64/Kconfig
+index 93173f0a0..60ec3e2aa 100644
+--- a/arch/arm64/Kconfig
++++ b/arch/arm64/Kconfig
+@@ -489,6 +489,27 @@ config AMPERE_ERRATUM_AC04_CPU_23
+ config ARM64_WORKAROUND_CLEAN_CACHE
+ 	bool
+ 
++config ALTRA_ERRATUM_82288
++	bool "Ampere Altra: 82288: PCIE_65: PCIe Root Port outbound write combining issue"
++	default y
++	help
++	  This option adds an alternative code sequence to work around
++	  Ampere Altra erratum 82288.
++
++	  PCIe device drivers may map MMIO space as Normal, non-cacheable
++	  memory attribute (e.g. Linux kernel drivers mapping MMIO
++	  using ioremap_wc). This may be for the purpose of enabling write
++	  combining or unaligned accesses. This can result in data corruption
++	  on the PCIe interface’s outbound MMIO writes due to issues with the
++	  write-combining operation.
++
++	  The workaround modifies software that maps PCIe MMIO space as Normal,
++	  non-cacheable memory (e.g. ioremap_wc) to instead Device,
++	  non-gatheringmemory (e.g. ioremap). And all memory operations on PCIe
++	  MMIO space must be strictly aligned.
++
++	  If unsure, say Y.
++
+ config ARM64_ERRATUM_826319
+ 	bool "Cortex-A53: 826319: System might deadlock if a write cannot complete until read data is accepted"
+ 	default y
+diff --git a/arch/arm64/include/asm/pci.h b/arch/arm64/include/asm/pci.h
+index 016eb6b46..edf663ec9 100644
+--- a/arch/arm64/include/asm/pci.h
++++ b/arch/arm64/include/asm/pci.h
+@@ -18,6 +18,12 @@
+ 
+ #define arch_can_pci_mmap_wc() 1
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++extern struct static_key_false have_altra_erratum_82288;
++
++bool is_pci_mmio(phys_addr_t phys_addr, size_t size);
++#endif
++
+ /* Generic PCI */
+ #include <asm-generic/pci.h>
+ 
+diff --git a/arch/arm64/include/asm/pgtable.h b/arch/arm64/include/asm/pgtable.h
+index 5ab5fe3be..b7dc8af15 100644
+--- a/arch/arm64/include/asm/pgtable.h
++++ b/arch/arm64/include/asm/pgtable.h
+@@ -342,11 +342,6 @@ static inline pte_t pte_mkyoung(pte_t pte)
+ 	return set_pte_bit(pte, __pgprot(PTE_AF));
+ }
+ 
+-static inline pte_t pte_mkspecial(pte_t pte)
+-{
+-	return set_pte_bit(pte, __pgprot(PTE_SPECIAL));
+-}
+-
+ static inline pte_t pte_mkcont(pte_t pte)
+ {
+ 	return set_pte_bit(pte, __pgprot(PTE_CONT));
+@@ -806,6 +801,27 @@ static inline void __set_puds(struct mm_struct *mm,
+ 	__pgprot_modify(prot, PTE_ATTRINDX_MASK, \
+ 			PTE_ATTRINDX(MT_NORMAL_NC) | PTE_PXN | PTE_UXN)
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++extern struct static_key_false have_altra_erratum_82288;
++
++bool is_pci_mmio(phys_addr_t phys_addr, size_t size);
++#endif
++
++static inline pte_t pte_mkspecial(pte_t pte)
++{
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++	phys_addr_t phys = __pte_to_phys(pte);
++	pgprot_t prot = __pgprot(pte_val(pte) & ~__phys_to_pte_val(__pte_to_phys(__pte(~0ull))));
++
++	if (static_branch_unlikely(&have_altra_erratum_82288) &&
++	    is_pci_mmio(phys, PAGE_SIZE)) {
++		pte = __pte(__phys_to_pte_val(phys) | pgprot_val(pgprot_device(prot)));
++	}
++#endif
++
++	return set_pte_bit(pte, __pgprot(PTE_SPECIAL));
++}
++
+ #define __HAVE_PHYS_MEM_ACCESS_PROT
+ struct file;
+ extern pgprot_t phys_mem_access_prot(struct file *file, unsigned long pfn,
+diff --git a/arch/arm64/mm/ioremap.c b/arch/arm64/mm/ioremap.c
+index 1e4794a2a..2f7d1ad28 100644
+--- a/arch/arm64/mm/ioremap.c
++++ b/arch/arm64/mm/ioremap.c
+@@ -2,6 +2,7 @@
+ 
+ #include <linux/mm.h>
+ #include <linux/io.h>
++#include <linux/pci.h>
+ 
+ static ioremap_prot_hook_t ioremap_prot_hook;
+ 
+@@ -14,6 +15,29 @@ int arm64_ioremap_prot_hook_register(ioremap_prot_hook_t hook)
+ 	return 0;
+ }
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++DEFINE_STATIC_KEY_FALSE(have_altra_erratum_82288);
++
++bool is_pci_mmio(phys_addr_t phys_addr, size_t size)
++{
++	struct pci_host_bridge *bridge;
++	struct resource_entry *entry;
++	struct resource res;
++	struct pci_bus *bus;
++
++	res = DEFINE_RES_MEM(phys_addr, size);
++	bus = NULL;
++	while ((bus = pci_find_next_bus(bus)) != NULL) {
++		bridge = to_pci_host_bridge(bus->bridge);
++		resource_list_for_each_entry(entry, &bridge->windows) {
++			if (resource_contains(entry->res, &res))
++				return true;
++		}
++	}
++	return false;
++}
++#endif
++
+ void __iomem *__ioremap_prot(phys_addr_t phys_addr, size_t size,
+ 			     pgprot_t pgprot)
+ {
+@@ -36,6 +60,12 @@ void __iomem *__ioremap_prot(phys_addr_t phys_addr, size_t size,
+ 		return NULL;
+ 	}
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++	if (static_branch_unlikely(&have_altra_erratum_82288) &&
++	    is_pci_mmio(phys_addr, size))
++		pgprot = pgprot_device(pgprot);
++#endif
++
+ 	return generic_ioremap_prot(phys_addr, size, pgprot);
+ }
+ EXPORT_SYMBOL(__ioremap_prot);
+diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
+index fd86f72f5..4cb656798 100644
+--- a/drivers/pci/quirks.c
++++ b/drivers/pci/quirks.c
+@@ -6346,6 +6346,17 @@ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_XILINX, 0x5021, of_pci_make_dev_node);
+ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_REDHAT, 0x0005, of_pci_make_dev_node);
+ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_EFAR, 0x9660, of_pci_make_dev_node);
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++static void quirk_altra_erratum_82288(struct pci_dev *dev)
++{
++	pr_info_once("Write combining PCI maps disabled due to hardware erratum\n");
++	static_branch_enable(&have_altra_erratum_82288);
++}
++DECLARE_PCI_FIXUP_EARLY(PCI_VENDOR_ID_AMPERE, 0xe100, quirk_altra_erratum_82288);
++static int setup_ampere_altra_pcie_65(char *) { quirk_altra_erratum_82288(NULL); return 0; }
++early_param("ampere_altra_pcie_65", setup_ampere_altra_pcie_65);
++#endif
++
+ /*
+  * Devices known to require a longer delay before first config space access
+  * after reset recovery or resume from D3cold:
+-- 
+2.52.0
+


### PR DESCRIPTION
Fix: https://github.com/AmpereComputing/linux-ampere-altra-erratum-pcie-65/issues/17