### PR TITLE
Rebase for v7.2

### DIFF
--- a/v6.19.7/0001-ampere-arm64-Add-a-fixup-handler-for-alignment-fault.patch
+++ b/v6.19.7/0001-ampere-arm64-Add-a-fixup-handler-for-alignment-fault.patch
@@ -1,0 +1,1 @@
+../v6.15/0001-ampere-arm64-Add-a-fixup-handler-for-alignment-fault.patch

--- a/v6.19.7/0002-ampere-arm64-Work-around-Ampere-Altra-erratum-82288-.patch
+++ b/v6.19.7/0002-ampere-arm64-Work-around-Ampere-Altra-erratum-82288-.patch
@@ -1,0 +1,207 @@
+From 1b53d0be267773731107d01dfe3d36764ce8ff0f Mon Sep 17 00:00:00 2001
+From: D Scott Phillips <scott@os.amperecomputing.com>
+Date: Tue, 13 Feb 2024 11:08:06 -0800
+Subject: [PATCH 2/2] ampere/arm64: Work around Ampere Altra erratum #82288
+ PCIE_65
+
+Altra's PCIe controller may generate incorrect addresses when receiving
+writes from the CPU with a discontiguous set of byte enables. Attempt to
+work around this by handing out Device-nGnRE maps instead of Normal
+Non-cacheable maps for PCIe memory areas.
+
+Signed-off-by: D Scott Phillips <scott@os.amperecomputing.com>
+---
+ Documentation/arch/arm64/silicon-errata.rst |  2 ++
+ arch/arm64/Kconfig                          | 21 +++++++++++++++
+ arch/arm64/include/asm/pci.h                |  6 +++++
+ arch/arm64/include/asm/pgtable.h            | 26 ++++++++++++++----
+ arch/arm64/mm/ioremap.c                     | 30 +++++++++++++++++++++
+ drivers/pci/quirks.c                        | 11 ++++++++
+ 6 files changed, 91 insertions(+), 5 deletions(-)
+
+diff --git a/Documentation/arch/arm64/silicon-errata.rst b/Documentation/arch/arm64/silicon-errata.rst
+index a7ec57060..ff763cd3d 100644
+--- a/Documentation/arch/arm64/silicon-errata.rst
++++ b/Documentation/arch/arm64/silicon-errata.rst
+@@ -53,6 +53,8 @@ stable kernels.
+ | Allwinner      | A64/R18         | UNKNOWN1        | SUN50I_ERRATUM_UNKNOWN1     |
+ +----------------+-----------------+-----------------+-----------------------------+
+ +----------------+-----------------+-----------------+-----------------------------+
++| Ampere         | Altra           | #82288          | ALTRA_ERRATUM_82288         |
+++----------------+-----------------+-----------------+-----------------------------+
+ | Ampere         | AmpereOne       | AC03_CPU_38     | AMPERE_ERRATUM_AC03_CPU_38  |
+ +----------------+-----------------+-----------------+-----------------------------+
+ | Ampere         | AmpereOne AC04  | AC04_CPU_10     | AMPERE_ERRATUM_AC03_CPU_38  |
+diff --git a/arch/arm64/Kconfig b/arch/arm64/Kconfig
+index 93173f0a0..60ec3e2aa 100644
+--- a/arch/arm64/Kconfig
++++ b/arch/arm64/Kconfig
+@@ -489,6 +489,27 @@ config AMPERE_ERRATUM_AC04_CPU_23
+ config ARM64_WORKAROUND_CLEAN_CACHE
+ 	bool
+ 
++config ALTRA_ERRATUM_82288
++	bool "Ampere Altra: 82288: PCIE_65: PCIe Root Port outbound write combining issue"
++	default y
++	help
++	  This option adds an alternative code sequence to work around
++	  Ampere Altra erratum 82288.
++
++	  PCIe device drivers may map MMIO space as Normal, non-cacheable
++	  memory attribute (e.g. Linux kernel drivers mapping MMIO
++	  using ioremap_wc). This may be for the purpose of enabling write
++	  combining or unaligned accesses. This can result in data corruption
++	  on the PCIe interface’s outbound MMIO writes due to issues with the
++	  write-combining operation.
++
++	  The workaround modifies software that maps PCIe MMIO space as Normal,
++	  non-cacheable memory (e.g. ioremap_wc) to instead Device,
++	  non-gatheringmemory (e.g. ioremap). And all memory operations on PCIe
++	  MMIO space must be strictly aligned.
++
++	  If unsure, say Y.
++
+ config ARM64_ERRATUM_826319
+ 	bool "Cortex-A53: 826319: System might deadlock if a write cannot complete until read data is accepted"
+ 	default y
+diff --git a/arch/arm64/include/asm/pci.h b/arch/arm64/include/asm/pci.h
+index 016eb6b46..edf663ec9 100644
+--- a/arch/arm64/include/asm/pci.h
++++ b/arch/arm64/include/asm/pci.h
+@@ -18,6 +18,12 @@
+ 
+ #define arch_can_pci_mmap_wc() 1
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++extern struct static_key_false have_altra_erratum_82288;
++
++bool is_pci_mmio(phys_addr_t phys_addr, size_t size);
++#endif
++
+ /* Generic PCI */
+ #include <asm-generic/pci.h>
+ 
+diff --git a/arch/arm64/include/asm/pgtable.h b/arch/arm64/include/asm/pgtable.h
+index 5ab5fe3be..b7dc8af15 100644
+--- a/arch/arm64/include/asm/pgtable.h
++++ b/arch/arm64/include/asm/pgtable.h
+@@ -342,11 +342,6 @@ static inline pte_t pte_mkyoung(pte_t pte)
+ 	return set_pte_bit(pte, __pgprot(PTE_AF));
+ }
+ 
+-static inline pte_t pte_mkspecial(pte_t pte)
+-{
+-	return set_pte_bit(pte, __pgprot(PTE_SPECIAL));
+-}
+-
+ static inline pte_t pte_mkcont(pte_t pte)
+ {
+ 	return set_pte_bit(pte, __pgprot(PTE_CONT));
+@@ -806,6 +801,27 @@ static inline void __set_puds(struct mm_struct *mm,
+ 	__pgprot_modify(prot, PTE_ATTRINDX_MASK, \
+ 			PTE_ATTRINDX(MT_NORMAL_NC) | PTE_PXN | PTE_UXN)
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++extern struct static_key_false have_altra_erratum_82288;
++
++bool is_pci_mmio(phys_addr_t phys_addr, size_t size);
++#endif
++
++static inline pte_t pte_mkspecial(pte_t pte)
++{
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++	phys_addr_t phys = __pte_to_phys(pte);
++	pgprot_t prot = __pgprot(pte_val(pte) & ~__phys_to_pte_val(__pte_to_phys(__pte(~0ull))));
++
++	if (static_branch_unlikely(&have_altra_erratum_82288) &&
++	    is_pci_mmio(phys, PAGE_SIZE)) {
++		pte = __pte(__phys_to_pte_val(phys) | pgprot_val(pgprot_device(prot)));
++	}
++#endif
++
++	return set_pte_bit(pte, __pgprot(PTE_SPECIAL));
++}
++
+ #define __HAVE_PHYS_MEM_ACCESS_PROT
+ struct file;
+ extern pgprot_t phys_mem_access_prot(struct file *file, unsigned long pfn,
+diff --git a/arch/arm64/mm/ioremap.c b/arch/arm64/mm/ioremap.c
+index 1e4794a2a..2f7d1ad28 100644
+--- a/arch/arm64/mm/ioremap.c
++++ b/arch/arm64/mm/ioremap.c
+@@ -2,6 +2,7 @@
+ 
+ #include <linux/mm.h>
+ #include <linux/io.h>
++#include <linux/pci.h>
+ 
+ static ioremap_prot_hook_t ioremap_prot_hook;
+ 
+@@ -14,6 +15,29 @@ int arm64_ioremap_prot_hook_register(ioremap_prot_hook_t hook)
+ 	return 0;
+ }
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++DEFINE_STATIC_KEY_FALSE(have_altra_erratum_82288);
++
++bool is_pci_mmio(phys_addr_t phys_addr, size_t size)
++{
++	struct pci_host_bridge *bridge;
++	struct resource_entry *entry;
++	struct resource res;
++	struct pci_bus *bus;
++
++	res = DEFINE_RES_MEM(phys_addr, size);
++	bus = NULL;
++	while ((bus = pci_find_next_bus(bus)) != NULL) {
++		bridge = to_pci_host_bridge(bus->bridge);
++		resource_list_for_each_entry(entry, &bridge->windows) {
++			if (resource_contains(entry->res, &res))
++				return true;
++		}
++	}
++	return false;
++}
++#endif
++
+ void __iomem *__ioremap_prot(phys_addr_t phys_addr, size_t size,
+ 			     pgprot_t pgprot)
+ {
+@@ -36,6 +60,12 @@ void __iomem *__ioremap_prot(phys_addr_t phys_addr, size_t size,
+ 		return NULL;
+ 	}
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++	if (static_branch_unlikely(&have_altra_erratum_82288) &&
++	    is_pci_mmio(phys_addr, size))
++		pgprot = pgprot_device(pgprot);
++#endif
++
+ 	return generic_ioremap_prot(phys_addr, size, pgprot);
+ }
+ EXPORT_SYMBOL(__ioremap_prot);
+diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
+index fd86f72f5..4cb656798 100644
+--- a/drivers/pci/quirks.c
++++ b/drivers/pci/quirks.c
+@@ -6346,6 +6346,17 @@ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_XILINX, 0x5021, of_pci_make_dev_node);
+ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_REDHAT, 0x0005, of_pci_make_dev_node);
+ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_EFAR, 0x9660, of_pci_make_dev_node);
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++static void quirk_altra_erratum_82288(struct pci_dev *dev)
++{
++	pr_info_once("Write combining PCI maps disabled due to hardware erratum\n");
++	static_branch_enable(&have_altra_erratum_82288);
++}
++DECLARE_PCI_FIXUP_EARLY(PCI_VENDOR_ID_AMPERE, 0xe100, quirk_altra_erratum_82288);
++static int setup_ampere_altra_pcie_65(char *) { quirk_altra_erratum_82288(NULL); return 0; }
++early_param("ampere_altra_pcie_65", setup_ampere_altra_pcie_65);
++#endif
++
+ /*
+  * Devices known to require a longer delay before first config space access
+  * after reset recovery or resume from D3cold:
+-- 
+2.52.0
+

--- a/v7.2/0001-ampere-arm64-Add-a-fixup-handler-for-alignment-fault.patch
+++ b/v7.2/0001-ampere-arm64-Add-a-fixup-handler-for-alignment-fault.patch
@@ -1,0 +1,1208 @@
+From 30fe4465615fdba2b26025c51cc25cc1aa96e1d3 Mon Sep 17 00:00:00 2001
+From: D Scott Phillips <scott@os.amperecomputing.com>
+Date: Tue, 13 Feb 2024 09:01:07 -0800
+Subject: [PATCH 1/2] ampere/arm64: Add a fixup handler for alignment faults in
+ aarch64 code
+
+A later patch will hand out Device memory in some cases to code
+which expects a Normal memory type, as an errata workaround.
+Unaligned accesses to Device memory will fault though, so here we
+add a fixup handler to emulate faulting accesses, at a performance
+penalty.
+
+Not all instructions in the Loads and Stores group are supported.
+Unsupported instructions are:
+
+ * Load/store memory tags
+ * Load/store exclusive
+ * LDAPR/STLR (unscaled immediate)
+ * Load register (literal) [cannot Alignment fault]
+ * Atomic memory operations
+ * Load/store register (pac)
+
+Instruction implementations are translated from the Exploration tools'
+ASL specifications.
+
+Signed-off-by: D Scott Phillips <scott@os.amperecomputing.com>
+---
+ arch/arm64/include/asm/exception.h |    1 +
+ arch/arm64/kernel/Makefile         |    5 +-
+ arch/arm64/kernel/alignment.c      | 1120 ++++++++++++++++++++++++++++
+ arch/arm64/mm/fault.c              |    5 +-
+ 4 files changed, 1128 insertions(+), 3 deletions(-)
+ create mode 100644 arch/arm64/kernel/alignment.c
+
+diff --git a/arch/arm64/include/asm/exception.h b/arch/arm64/include/asm/exception.h
+index a2da3cb21c24..c9a6c3d2f68e 100644
+--- a/arch/arm64/include/asm/exception.h
++++ b/arch/arm64/include/asm/exception.h
+@@ -81,6 +81,7 @@ void do_el0_sys(unsigned long esr, struct pt_regs *regs);
+ void do_sp_pc_abort(unsigned long addr, unsigned long esr, struct pt_regs *regs);
+ void bad_el0_sync(struct pt_regs *regs, int reason, unsigned long esr);
+ void do_el0_cp15(unsigned long esr, struct pt_regs *regs);
++int do_alignment_fixup(unsigned long addr, unsigned int esr, struct pt_regs *regs);
+ int do_compat_alignment_fixup(unsigned long addr, struct pt_regs *regs);
+ void do_el0_svc(struct pt_regs *regs);
+ void do_el0_svc_compat(struct pt_regs *regs);
+diff --git a/arch/arm64/kernel/Makefile b/arch/arm64/kernel/Makefile
+index d2690c3ec528..d6294a638153 100644
+--- a/arch/arm64/kernel/Makefile
++++ b/arch/arm64/kernel/Makefile
+@@ -25,8 +25,11 @@ KASAN_SANITIZE_stacktrace.o := n
+ KCOV_INSTRUMENT_entry-common.o := n
+ KCOV_INSTRUMENT_idle.o := n
+ 
++CFLAGS_alignment.o		+= $(CC_FLAGS_FPU)
++CFLAGS_REMOVE_alignment.o	+= $(CC_FLAGS_NO_FPU)
++
+ # Object file lists.
+-obj-y			:= debug-monitors.o entry.o irq.o fpsimd.o		\
++obj-y			:= alignment.o debug-monitors.o entry.o irq.o fpsimd.o	\
+ 			   entry-common.o process.o ptrace.o			\
+ 			   setup.o signal.o sys.o stacktrace.o time.o traps.o	\
+ 			   io.o vdso.o hyp-stub.o psci.o cpu_ops.o		\
+diff --git a/arch/arm64/kernel/alignment.c b/arch/arm64/kernel/alignment.c
+new file mode 100644
+index 000000000000..9e4e8d61f8ce
+--- /dev/null
++++ b/arch/arm64/kernel/alignment.c
+@@ -0,0 +1,1120 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * Copyright (C) 2023 Ampere Computing LLC
++ */
++
++#include <linux/init.h>
++#include <linux/io.h>
++#include <linux/perf_event.h>
++#include <linux/printk.h>
++#include <linux/uaccess.h>
++
++#include <asm/exception.h>
++#include <asm/insn.h>
++#include <asm/text-patching.h>
++#include <asm/ptrace.h>
++#include <asm/traps.h>
++
++static __always_inline int __aarch64_insn_is_class_ldst(u32 insn)
++{
++	return (insn & 0x0A000000) == 0x08000000;
++}
++
++static __always_inline int __aarch64_insn_is_dc_zva(u32 insn)
++{
++	return (insn & 0xFFFFFFE0) == 0xD50B7420;
++}
++
++static int copy_from_user_io(void *to, const void __user *from, unsigned long n)
++{
++	const u8 __user *src = from;
++	u8 *dest = to;
++
++	for (; n; n--)
++		if (get_user(*dest++, src++))
++			break;
++	return n;
++}
++
++static int copy_to_user_io(void __user *to, const void *from, unsigned long n)
++{
++	const u8 *src = from;
++	u8 __user *dest = to;
++
++	for (; n; n--)
++		if (put_user(*src++, dest++))
++			break;
++	return n;
++}
++
++static int align_load(unsigned long addr, int sz, u64 *out)
++{
++	union {
++		u8 d8;
++		u16 d16;
++		u32 d32;
++		u64 d64;
++		char c[8];
++	} data;
++
++	if (sz != 1 && sz != 2 && sz != 4 && sz != 8)
++		return 1;
++	if (is_ttbr0_addr(addr)) {
++		if (copy_from_user_io(data.c, (const void __user *)addr, sz))
++			return 1;
++	} else
++		memcpy_fromio(data.c, (const void __iomem *)addr, sz);
++	switch (sz) {
++	case 1:
++		*out = data.d8;
++		break;
++	case 2:
++		*out = data.d16;
++		break;
++	case 4:
++		*out = data.d32;
++		break;
++	case 8:
++		*out = data.d64;
++		break;
++	default:
++		return 1;
++	}
++	return 0;
++}
++
++static int align_store(unsigned long addr, int sz, u64 val)
++{
++	union {
++		u8 d8;
++		u16 d16;
++		u32 d32;
++		u64 d64;
++		char c[8];
++	} data;
++
++	switch (sz) {
++	case 1:
++		data.d8 = val;
++		break;
++	case 2:
++		data.d16 = val;
++		break;
++	case 4:
++		data.d32 = val;
++		break;
++	case 8:
++		data.d64 = val;
++		break;
++	default:
++		return 1;
++	}
++	if (is_ttbr0_addr(addr)) {
++		if (copy_to_user_io((void __user *)addr, data.c, sz))
++			return 1;
++	} else
++		memcpy_toio((void __iomem *)addr, data.c, sz);
++	return 0;
++}
++
++static int align_dc_zva(unsigned long addr, struct pt_regs *regs)
++{
++	int bs = read_cpuid(DCZID_EL0) & 0xf;
++	int sz = 1 << (bs + 2);
++
++	addr &= ~(sz - 1);
++	if (is_ttbr0_addr(addr)) {
++		for (; sz; sz--) {
++			if (align_store(addr++, 1, 0))
++				return 1;
++		}
++	} else
++		memset_io((void __iomem *)addr, 0, sz);
++	return 0;
++}
++
++static u64 get_vn_dt(int n, int t)
++{
++	u64 res;
++
++	switch (n) {
++#define V(n)						\
++	case n:						\
++		asm("cbnz %w1, 1f\n\t"			\
++		    "mov %0, v"#n".d[0]\n\t"		\
++		    "b 2f\n\t"				\
++		    "1: mov %0, v"#n".d[1]\n\t"		\
++		    "2:" : "=r" (res) : "r" (t));	\
++		break					\
++
++	V(0);  V(1);  V(2);  V(3);  V(4);  V(5);  V(6);  V(7);
++	V(8);  V(9);  V(10); V(11); V(12); V(13); V(14); V(15);
++	V(16); V(17); V(18); V(19); V(20); V(21); V(22); V(23);
++	V(24); V(25); V(26); V(27); V(28); V(29); V(30); V(31);
++#undef V
++	default:
++		res = 0;
++		break;
++	}
++	return res;
++}
++
++static void set_vn_dt(int n, int t, u64 val)
++{
++	switch (n) {
++#define V(n)						\
++	case n:						\
++		asm("cbnz %w1, 1f\n\t"			\
++		    "mov v"#n".d[0], %0\n\t"		\
++		    "b 2f\n\t"				\
++		    "1: mov v"#n".d[1], %0\n\t"		\
++		    "2:" :: "r" (val), "r" (t));	\
++		break					\
++
++	V(0);  V(1);  V(2);  V(3);  V(4);  V(5);  V(6);  V(7);
++	V(8);  V(9);  V(10); V(11); V(12); V(13); V(14); V(15);
++	V(16); V(17); V(18); V(19); V(20); V(21); V(22); V(23);
++	V(24); V(25); V(26); V(27); V(28); V(29); V(30); V(31);
++#undef Q
++	default:
++		break;
++	}
++}
++
++static u64 replicate64(u64 val, int bits)
++{
++	switch (bits) {
++	case 8:
++		val = (val << 8) | (val & 0xff);
++		fallthrough;
++	case 16:
++		val = (val << 16) | (val & 0xffff);
++		fallthrough;
++	case 32:
++		val = (val << 32) | (val & 0xffffffff);
++		break;
++	default:
++		break;
++	}
++	return val;
++}
++
++static u64 elem_get(u64 hi, u64 lo, int index, int esize)
++{
++	int shift = index * esize;
++	u64 mask = GENMASK(esize - 1, 0);
++
++	if (shift < 64)
++		return (lo >> shift) & mask;
++	else
++		return (hi >> (shift - 64)) & mask;
++}
++
++static void elem_set(u64 *hi, u64 *lo, int index, int esize, u64 val)
++{
++	int shift = index * esize;
++	u64 mask = GENMASK(esize - 1, 0);
++
++	if (shift < 64)
++		*lo = (*lo & ~(mask << shift)) | ((val & mask) << shift);
++	else
++		*hi = (*hi & ~(mask << (shift - 64))) | ((val & mask) << (shift - 64));
++}
++
++static int align_ldst_pair(u32 insn, struct pt_regs *regs)
++{
++	const u32 OPC = GENMASK(31, 30);
++	const u32 L_MASK = BIT(22);
++
++	int opc = FIELD_GET(OPC, insn);
++	int L = FIELD_GET(L_MASK, insn);
++
++	bool wback = !!(insn & BIT(23));
++	bool postindex = !(insn & BIT(24));
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int t2 = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT2, insn);
++	bool is_store = !L;
++	bool is_signed = !!(opc & 1);
++	int scale = 2 + (opc >> 1);
++	int datasize = 8 << scale;
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_7, insn);
++	s64 offset = sign_extend64(uoffset, 6) << scale;
++	u64 address;
++	u64 data1, data2;
++	u64 dbytes;
++
++	if ((is_store && (opc & 1)) || opc == 3)
++		return 1;
++
++	if (wback && (t == n || t2 == n) && n != 31)
++		return 1;
++
++	if (!is_store && t == t2)
++		return 1;
++
++	dbytes = datasize / 8;
++
++	address = regs_get_register(regs, n << 3);
++
++	if (!postindex)
++		address += offset;
++
++	if (is_store) {
++		data1 = pt_regs_read_reg(regs, t);
++		data2 = pt_regs_read_reg(regs, t2);
++		if (align_store(address, dbytes, data1) ||
++		    align_store(address + dbytes, dbytes, data2))
++			return 1;
++	} else {
++		if (align_load(address, dbytes, &data1) ||
++		    align_load(address + dbytes, dbytes, &data2))
++			return 1;
++		if (is_signed) {
++			data1 = sign_extend64(data1, datasize - 1);
++			data2 = sign_extend64(data2, datasize - 1);
++		}
++		pt_regs_write_reg(regs, t, data1);
++		pt_regs_write_reg(regs, t2, data2);
++	}
++
++	if (wback) {
++		if (postindex)
++			address += offset;
++		if (n == 31)
++			regs->sp = address;
++		else
++			pt_regs_write_reg(regs, n, address);
++	}
++
++	return 0;
++}
++
++static int align_ldst_pair_simdfp(u32 insn, struct pt_regs *regs)
++{
++	const u32 OPC = GENMASK(31, 30);
++	const u32 L_MASK = BIT(22);
++
++	int opc = FIELD_GET(OPC, insn);
++	int L = FIELD_GET(L_MASK, insn);
++
++	bool wback = !!(insn & BIT(23));
++	bool postindex = !(insn & BIT(24));
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int t2 = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT2, insn);
++	bool is_store = !L;
++	int scale = 2 + opc;
++	int datasize = 8 << scale;
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_7, insn);
++	s64 offset = sign_extend64(uoffset, 6) << scale;
++	u64 address;
++	u64 data1_d0, data1_d1, data2_d0, data2_d1;
++	u64 dbytes;
++
++	if (opc == 0x3)
++		return 1;
++
++	if (!is_store && t == t2)
++		return 1;
++
++	dbytes = datasize / 8;
++
++	address = regs_get_register(regs, n << 3);
++
++	if (!postindex)
++		address += offset;
++
++	if (is_store) {
++		data1_d0 = get_vn_dt(t, 0);
++		data2_d0 = get_vn_dt(t2, 0);
++		if (datasize == 128) {
++			data1_d1 = get_vn_dt(t, 1);
++			data2_d1 = get_vn_dt(t2, 1);
++			if (align_store(address, 8, data1_d0) ||
++			    align_store(address + 8, 8, data1_d1) ||
++			    align_store(address + 16, 8, data2_d0) ||
++			    align_store(address + 24, 8, data2_d1))
++				return 1;
++		} else {
++			if (align_store(address, dbytes, data1_d0) ||
++			    align_store(address + dbytes, dbytes, data2_d0))
++				return 1;
++		}
++	} else {
++		if (datasize == 128) {
++			if (align_load(address, 8, &data1_d0) ||
++			    align_load(address + 8, 8, &data1_d1) ||
++			    align_load(address + 16, 8, &data2_d0) ||
++			    align_load(address + 24, 8, &data2_d1))
++				return 1;
++		} else {
++			if (align_load(address, dbytes, &data1_d0) ||
++			    align_load(address + dbytes, dbytes, &data2_d0))
++				return 1;
++			data1_d1 = data2_d1 = 0;
++		}
++		set_vn_dt(t, 0, data1_d0);
++		set_vn_dt(t, 1, data1_d1);
++		set_vn_dt(t2, 0, data2_d0);
++		set_vn_dt(t2, 1, data2_d1);
++	}
++
++	if (wback) {
++		if (postindex)
++			address += offset;
++		if (n == 31)
++			regs->sp = address;
++		else
++			pt_regs_write_reg(regs, n, address);
++	}
++
++	return 0;
++}
++
++static int align_ldst_regoff(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++	const u32 OPTION = GENMASK(15, 13);
++	const u32 S = BIT(12);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	u32 option = FIELD_GET(OPTION, insn);
++	u32 s = FIELD_GET(S, insn);
++	int scale = size;
++	int extend_len = (option & 0x1) ? 64 : 32;
++	bool extend_unsigned = !(option & 0x4);
++	int shift = s ? scale : 0;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int m = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RM, insn);
++	bool is_store;
++	bool is_signed;
++	int regsize;
++	int datasize;
++	u64 offset;
++	u64 address;
++	u64 data;
++
++	if ((opc & 0x2) == 0) {
++		/* store or zero-extending load */
++		is_store = !(opc & 0x1);
++		regsize = size == 0x3 ? 64 : 32;
++		is_signed = false;
++	} else {
++		if (size == 0x3) {
++			if ((opc & 0x1) == 0) {
++				/* prefetch */
++				return 0;
++			}
++			/* undefined */
++			return 1;
++		}
++		/* sign-extending load */
++		is_store = false;
++		if (size == 0x2 && (opc & 0x1) == 0x1) {
++			/* undefined */
++			return 1;
++		}
++		regsize = (opc & 0x1) == 0x1 ? 32 : 64;
++		is_signed = true;
++	}
++
++	datasize = 8 << scale;
++
++	offset = pt_regs_read_reg(regs, m);
++	if (extend_len == 32) {
++		offset &= (u32)~0;
++		if (!extend_unsigned)
++			sign_extend64(offset, 31);
++	}
++	offset <<= shift;
++
++	address = regs_get_register(regs, n << 3) + offset;
++
++	if (is_store) {
++		data = pt_regs_read_reg(regs, t);
++		if (align_store(address, datasize / 8, data))
++			return 1;
++	} else {
++		if (align_load(address, datasize / 8, &data))
++			return 1;
++		if (is_signed) {
++			if (regsize == 32)
++				data = sign_extend32(data, datasize - 1);
++			else
++				data = sign_extend64(data, datasize - 1);
++		}
++		pt_regs_write_reg(regs, t, data);
++	}
++
++	return 0;
++}
++
++static int align_ldst_regoff_simdfp(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++	const u32 OPTION = GENMASK(15, 13);
++	const u32 S = BIT(12);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	u32 option = FIELD_GET(OPTION, insn);
++	u32 s = FIELD_GET(S, insn);
++	int scale = (opc & 0x2) << 1 | size;
++	int extend_len = (option & 0x1) ? 64 : 32;
++	bool extend_unsigned = !(option & 0x4);
++	int shift = s ? scale : 0;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int m = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RM, insn);
++	bool is_store = !(opc & BIT(0));
++	int datasize;
++	u64 offset;
++	u64 address;
++	u64 data_d0, data_d1;
++
++	if ((option & 0x2) == 0)
++		return 1;
++
++	datasize = 8 << scale;
++
++	offset = pt_regs_read_reg(regs, m);
++	if (extend_len == 32) {
++		offset &= (u32)~0;
++		if (!extend_unsigned)
++			sign_extend64(offset, 31);
++	}
++	offset <<= shift;
++
++	address = regs_get_register(regs, n << 3) + offset;
++
++	if (is_store) {
++		data_d0 = get_vn_dt(t, 0);
++		if (datasize == 128) {
++			data_d1 = get_vn_dt(t, 1);
++			if (align_store(address, 8, data_d0) ||
++			    align_store(address + 8, 8, data_d1))
++				return 1;
++		} else {
++			if (align_store(address, datasize / 8, data_d0))
++				return 1;
++		}
++	} else {
++		if (datasize == 128) {
++			if (align_load(address, 8, &data_d0) ||
++			    align_load(address + 8, 8, &data_d1))
++				return 1;
++		} else {
++			if (align_load(address, datasize / 8, &data_d0))
++				return 1;
++			data_d1 = 0;
++		}
++		set_vn_dt(t, 0, data_d0);
++		set_vn_dt(t, 1, data_d1);
++	}
++
++	return 0;
++}
++
++static int align_ldst_imm(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	bool wback = !(insn & BIT(24)) && !!(insn & BIT(10));
++	bool postindex = wback && !(insn & BIT(11));
++	int scale = size;
++	u64 offset;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	bool is_store;
++	bool is_signed;
++	int regsize;
++	int datasize;
++	u64 address;
++	u64 data;
++
++	if (!(insn & BIT(24))) {
++		u64 uoffset =
++			aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++		offset = sign_extend64(uoffset, 8);
++	} else {
++		offset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_12, insn);
++		offset <<= scale;
++	}
++
++	if ((opc & 0x2) == 0) {
++		/* store or zero-extending load */
++		is_store = !(opc & 0x1);
++		regsize = size == 0x3 ? 64 : 32;
++		is_signed = false;
++	} else {
++		if (size == 0x3) {
++			if (FIELD_GET(GENMASK(11, 10), insn) == 0 && (opc & 0x1) == 0) {
++				/* prefetch */
++				return 0;
++			}
++			/* undefined */
++			return 1;
++		}
++		/* sign-extending load */
++		is_store = false;
++		if (size == 0x2 && (opc & 0x1) == 0x1) {
++			/* undefined */
++			return 1;
++		}
++		regsize = (opc & 0x1) == 0x1 ? 32 : 64;
++		is_signed = true;
++	}
++
++	datasize = 8 << scale;
++
++	if (wback && n == t && n != 31)
++		return 1;
++
++	address = regs_get_register(regs, n << 3);
++
++	if (!postindex)
++		address += offset;
++
++	if (is_store) {
++		data = pt_regs_read_reg(regs, t);
++		if (align_store(address, datasize / 8, data))
++			return 1;
++	} else {
++		if (align_load(address, datasize / 8, &data))
++			return 1;
++		if (is_signed) {
++			if (regsize == 32)
++				data = sign_extend32(data, datasize - 1);
++			else
++				data = sign_extend64(data, datasize - 1);
++		}
++		pt_regs_write_reg(regs, t, data);
++	}
++
++	if (wback) {
++		if (postindex)
++			address += offset;
++		if (n == 31)
++			regs->sp = address;
++		else
++			pt_regs_write_reg(regs, n, address);
++	}
++
++	return 0;
++}
++
++static int align_ldst_imm_simdfp(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++	bool wback = !(insn & BIT(24)) && !!(insn & BIT(10));
++	bool postindex = wback && !(insn & BIT(11));
++	int scale = (opc & 0x2) << 1 | size;
++	u64 offset;
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	bool is_store = !(opc & BIT(0));
++	int datasize;
++	u64 address;
++	u64 data_d0, data_d1;
++
++	if (scale > 4)
++		return 1;
++
++	if (!(insn & BIT(24))) {
++		u64 uoffset =
++			aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++		offset = sign_extend64(uoffset, 8);
++	} else {
++		offset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_12, insn);
++		offset <<= scale;
++	}
++
++	datasize = 8 << scale;
++
++	address = regs_get_register(regs, n << 3);
++
++	if (!postindex)
++		address += offset;
++
++	if (is_store) {
++		data_d0 = get_vn_dt(t, 0);
++		if (datasize == 128) {
++			data_d1 = get_vn_dt(t, 1);
++			if (align_store(address, 8, data_d0) ||
++			    align_store(address + 8, 8, data_d1))
++				return 1;
++		} else {
++			if (align_store(address, datasize / 8, data_d0))
++				return 1;
++		}
++	} else {
++		if (datasize == 128) {
++			if (align_load(address, 8, &data_d0) ||
++			    align_load(address + 8, 8, &data_d1))
++				return 1;
++		} else {
++			if (align_load(address, datasize / 8, &data_d0))
++				return 1;
++			data_d1 = 0;
++		}
++		set_vn_dt(t, 0, data_d0);
++		set_vn_dt(t, 1, data_d1);
++	}
++
++	if (wback) {
++		if (postindex)
++			address += offset;
++		if (n == 31)
++			regs->sp = address;
++		else
++			pt_regs_write_reg(regs, n, address);
++	}
++
++	return 0;
++}
++
++static int align_ldst_vector_multiple(u32 insn, struct pt_regs *regs)
++{
++	const u32 Q_MASK = BIT(30);
++	const u32 L_MASK = BIT(22);
++	const u32 OPCODE = GENMASK(15, 12);
++	const u32 SIZE = GENMASK(11, 10);
++
++	u32 Q = FIELD_GET(Q_MASK, insn);
++	u32 L = FIELD_GET(L_MASK, insn);
++	u32 opcode = FIELD_GET(OPCODE, insn);
++	u32 size = FIELD_GET(SIZE, insn);
++
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int m = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RM, insn);
++	bool wback = !!(insn & BIT(23));
++
++	int datasize = Q ? 128 : 64;
++	int esize = 8 << size;
++	int elements = datasize / esize;
++	int rpt;
++	int selem;
++	u64 address;
++	u64 offs;
++	u64 rval_d0, rval_d1;
++	int tt;
++	int ebytes;
++	int r;
++	int e;
++	int s;
++	u64 data;
++
++	switch (opcode) {
++	case 0: // LD/ST4 (4 registers)
++		rpt = 1;
++		selem = 4;
++		break;
++	case 2: // LD/ST1 (4 registers)
++		rpt = 4;
++		selem = 1;
++		break;
++	case 4: // LD/ST3 (3 registers)
++		rpt = 1;
++		selem = 3;
++		break;
++	case 6: // LD/ST1 (3 registers)
++		rpt = 3;
++		selem = 1;
++		break;
++	case 7: // LD/ST1 (1 register)
++		rpt = 1;
++		selem = 1;
++		break;
++	case 8: // LD/ST2 (2 registers)
++		rpt = 1;
++		selem = 2;
++		break;
++	case 10: // LD/ST1 (2 registers)
++		rpt = 2;
++		selem = 1;
++		break;
++	default:
++		return 1;
++	}
++
++	if (size == 3 && Q == 0 && selem != 1)
++		return 1;
++
++	ebytes = esize / 8;
++
++	address = regs_get_register(regs, n << 3);
++
++	offs = 0;
++
++	for (r = 0; r < rpt; r++) {
++		for (e = 0; e < elements; e++) {
++			tt = (t + r) % 32;
++			for (s = 0; s < selem; s++) {
++				rval_d0 = get_vn_dt(tt, 0);
++				rval_d1 = get_vn_dt(tt, 1);
++				if (L) {
++					if (align_load(address + offs, ebytes, &data))
++						return 1;
++					elem_set(&rval_d1, &rval_d0, e, esize, data);
++					set_vn_dt(tt, 0, rval_d0);
++					set_vn_dt(tt, 1, rval_d1);
++				} else {
++					data = elem_get(rval_d1, rval_d0, e, esize);
++					if (align_store(address + offs, ebytes, data))
++						return 1;
++				}
++				offs += ebytes;
++				tt = (tt + 1) % 32;
++			}
++		}
++	}
++
++	if (wback) {
++		if (m != 31)
++			offs = regs_get_register(regs, m << 3);
++		if (n == 31)
++			regs->sp = address + offs;
++		else
++			pt_regs_write_reg(regs, n, address + offs);
++	}
++
++	return 0;
++}
++
++static int align_ldst_vector_single(u32 insn, struct pt_regs *regs)
++{
++	const u32 Q_MASK = BIT(30);
++	const u32 L_MASK = BIT(22);
++	const u32 R_MASK = BIT(21);
++	const u32 OPCODE = GENMASK(15, 13);
++	const u32 S_MASK = BIT(12);
++	const u32 SIZE = GENMASK(11, 10);
++
++	u32 Q = FIELD_GET(Q_MASK, insn);
++	u32 L = FIELD_GET(L_MASK, insn);
++	u32 R = FIELD_GET(R_MASK, insn);
++	u32 opcode = FIELD_GET(OPCODE, insn);
++	u32 S = FIELD_GET(S_MASK, insn);
++	u32 size = FIELD_GET(SIZE, insn);
++
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int m = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RM, insn);
++	bool wback = !!(insn & BIT(23));
++
++	int init_scale = opcode >> 1;
++	int scale = init_scale;
++	int selem = (((opcode & 1) << 1) | R) + 1;
++	bool replicate = false;
++	int index;
++	int datasize;
++	int esize;
++	u64 address;
++	u64 offs;
++	u64 rval_d0, rval_d1;
++	u64 element;
++	int ebytes;
++	int s;
++	u64 data;
++
++	switch (scale) {
++	case 3:
++		if (!L || S)
++			return 1;
++		scale = size;
++		replicate = true;
++		break;
++	case 0:
++		index = (Q << 3) | (S << 2) | size;
++		break;
++	case 1:
++		if (size & 1)
++			return 1;
++		index = (Q << 2) | (S << 1) | (size >> 1);
++		break;
++	case 2:
++		if (size & 2)
++			return 1;
++		if (!(size & 1))
++			index = (Q << 1) | S;
++		else {
++			if (S)
++				return 1;
++			index = Q;
++			scale = 3;
++		}
++		break;
++	}
++
++	datasize = Q ? 128 : 64;
++	esize = 8 << scale;
++
++	ebytes = esize / 8;
++
++	address = regs_get_register(regs, n << 3);
++
++	offs = 0;
++
++	if (replicate) {
++		for (s = 0; s < selem; s++) {
++			if (align_load(address + offs, ebytes, &element))
++				return 1;
++			data = replicate64(element, esize);
++			set_vn_dt(t, 0, data);
++			if (datasize == 128)
++				set_vn_dt(t, 1, data);
++			else
++				set_vn_dt(t, 1, 0);
++			offs += ebytes;
++			t = (t + 1) & 31;
++		}
++	} else {
++		for (s = 0; s < selem; s++) {
++			rval_d0 = get_vn_dt(t, 0);
++			rval_d1 = get_vn_dt(t, 1);
++			if (L) {
++				if (align_load(address + offs, ebytes, &data))
++					return 1;
++				elem_set(&rval_d1, &rval_d0, index, esize, data);
++				set_vn_dt(t, 0, rval_d0);
++				set_vn_dt(t, 1, rval_d1);
++			} else {
++				data = elem_get(rval_d1, rval_d0, index, esize);
++				if (align_store(address + offs, ebytes, data))
++					return 1;
++			}
++			offs += ebytes;
++			t = (t + 1) & 31;
++		}
++	}
++
++	if (wback) {
++		if (m != 31)
++			offs = regs_get_register(regs, m << 3);
++		if (n == 31)
++			regs->sp = address + offs;
++		else
++			pt_regs_write_reg(regs, n, address + offs);
++	}
++
++	return 0;
++}
++
++static int align_ldst_unpriv(u32 insn, struct pt_regs *regs)
++{
++	const u32 SIZE = GENMASK(31, 30);
++	const u32 OPC = GENMASK(23, 22);
++
++	u32 size = FIELD_GET(SIZE, insn);
++	u32 opc = FIELD_GET(OPC, insn);
++
++	int scale = size;
++	u64 uoffset = aarch64_insn_decode_immediate(AARCH64_INSN_IMM_9, insn);
++	u64 offset = sign_extend64(uoffset, 8);
++
++	int n = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RN, insn);
++	int t = aarch64_insn_decode_register(AARCH64_INSN_REGTYPE_RT, insn);
++
++	bool is_store;
++	bool is_signed;
++	int regsize;
++	int datasize;
++	u64 address;
++	u64 data;
++
++	if ((opc & 0x2) == 0) {
++		is_store = (opc & 0x1) != 0x1;
++		regsize = size == 0x3 ? 64 : 32;
++		is_signed = false;
++	} else {
++		if (size == 0x3)
++			return 1;
++		is_store = false;
++		if (size == 2 && (opc & 0x1) == 0x1)
++			return 1;
++		regsize = (opc & 0x1) == 0x1 ? 32 : 64;
++		is_signed = true;
++	}
++
++	datasize = 8 << scale;
++
++	address = regs_get_register(regs, n << 3);
++
++	address += offset;
++
++	if (!is_ttbr0_addr(address))
++		return 1;
++
++	if (is_store) {
++		data = pt_regs_read_reg(regs, t);
++		if (align_store(address, datasize / 8, data))
++			return is_ttbr1_addr(regs->pc) &&
++				fixup_exception(regs, ESR_ELx_WNR) ? 0 : 1;
++	} else {
++		if (align_load(address, datasize / 8, &data))
++			return is_ttbr1_addr(regs->pc) &&
++				fixup_exception(regs, 0) ? 0 : 1;
++		if (is_signed) {
++			if (regsize == 32)
++				data = sign_extend32(data, datasize - 1);
++			else
++				data = sign_extend64(data, datasize - 1);
++		}
++		pt_regs_write_reg(regs, t, data);
++	}
++
++	return 0;
++}
++
++static int align_ldst(u32 insn, struct pt_regs *regs)
++{
++	const u32 op0 = FIELD_GET(GENMASK(31, 28), insn);
++	const u32 op1 = FIELD_GET(BIT(26), insn);
++	const u32 op2 = FIELD_GET(GENMASK(24, 23), insn);
++	const u32 op3 = FIELD_GET(GENMASK(21, 16), insn);
++	const u32 op4 = FIELD_GET(GENMASK(11, 10), insn);
++
++	if ((op0 & 0x3) == 0x2) {
++		/*
++		 * |------+-----+-----+-----+-----+-----------------------------------------|
++		 * | op0  | op1 | op2 | op3 | op4 | Decode group                            |
++		 * |------+-----+-----+-----+-----+-----------------------------------------|
++		 * | xx10 | -   |  00 | -   | -   | Load/store no-allocate pair (offset)    |
++		 * | xx10 | -   |  01 | -   | -   | Load/store register pair (post-indexed) |
++		 * | xx10 | -   |  10 | -   | -   | Load/store register pair (offset)       |
++		 * | xx10 | -   |  11 | -   | -   | Load/store register pair (pre-indexed)  |
++		 * |------+-----+-----+-----+-----+-----------------------------------------|
++		 */
++
++		if (op1 == 0) { /* V == 0 */
++			/* general */
++			return align_ldst_pair(insn, regs);
++		}
++		/* simdfp */
++		return align_ldst_pair_simdfp(insn, regs);
++	} else if ((op0 & 0x3) == 0x3 &&
++		   (((op2 & 0x2) == 0 && (op3 & 0x20) == 0 && op4 != 0x2) ||
++		    ((op2 & 0x2) == 0x2))) {
++		/*
++		 * |------+-----+-----+--------+-----+---------------------------------------------|
++		 * | op0  | op1 | op2 |    op3 | op4 | Decode group                                |
++		 * |------+-----+-----+--------+-----+---------------------------------------------|
++		 * | xx11 | -   |  0x | 0xxxxx |  00 | Load/store register (unscaled immediate)    |
++		 * | xx11 | -   |  0x | 0xxxxx |  01 | Load/store register (immediate post-indexed |
++		 * | xx11 | -   |  0x | 0xxxxx |  11 | Load/store register (immediate pre-indexed) |
++		 * | xx11 | -   |  1x |      - |   - | Load/store register (unsigned immediate)    |
++		 * |------+-----+-----+--------+-----+---------------------------------------------|
++		 */
++
++		if (op1 == 0) {  /* V == 0 */
++			/* general */
++			return align_ldst_imm(insn, regs);
++		}
++		/* simdfp */
++		return align_ldst_imm_simdfp(insn, regs);
++	} else if ((op0 & 0x3) == 0x3 && (op2 & 0x2) == 0 &&
++		   (op3 & 0x20) == 0x20 && op4 == 0x2) {
++		/*
++		 * |------+-----+-----+--------+-----+---------------------------------------|
++		 * | op0  | op1 | op2 |    op3 | op4 |                                       |
++		 * |------+-----+-----+--------+-----+---------------------------------------|
++		 * | xx11 | -   |  0x | 1xxxxx |  10 | Load/store register (register offset) |
++		 * |------+-----+-----+--------+-----+---------------------------------------|
++		 */
++		if (op1 == 0) { /* V == 0 */
++			/* general */
++			return align_ldst_regoff(insn, regs);
++		}
++		/* simdfp */
++		return align_ldst_regoff_simdfp(insn, regs);
++	} else if ((op0 & 0xb) == 0 && op1 == 1 &&
++		   ((op2 == 0 && op3 == 0) || (op2 == 1 && ((op3 & 0x20) == 0)))) {
++		/*
++		 * |------+-----+-----+--------+-----+---------------------------------------------|
++		 * | op0  | op1 | op2 |    op3 | op4 |                                             |
++		 * |------+-----+-----+--------+-----+---------------------------------------------|
++		 * | 0x00 |   1 |  00 | 000000 |   - | Advanced SIMD load/store multiple structure |
++		 * | 0x00 |   1 |  01 | 0xxxxx |   - | Advanced SIMD load/store multiple structure |
++		 * |      |     |     |        |     |   (post-indexed)                            |
++		 * |------+-----+-----+--------+-----+---------------------------------------------|
++		 */
++		return align_ldst_vector_multiple(insn, regs);
++	} else if ((op0 & 0xb) == 0 && op1 == 1 &&
++		   ((op2 == 2 && ((op3 & 0x1f) == 0)) || op2 == 3)) {
++		/*
++		 * |------+-----+-----+--------+-----+-------------------------------------------|
++		 * | op0  | op1 | op2 |    op3 | op4 |                                           |
++		 * |------+-----+-----+--------+-----+-------------------------------------------|
++		 * | 0x00 |   1 |  10 | x00000 |   - | Advanced SIMD load/store single structure |
++		 * | 0x00 |   1 |  11 |      - |   - | Advanced SIMD load/store single structure |
++		 * |      |     |     |        |     |   (post-indexed)                          |
++		 * |------+-----+-----+--------+-----+-------------------------------------------|
++		 */
++		return align_ldst_vector_single(insn, regs);
++	} else if ((op0 & 0x3) == 0x3 && (op2 & 0x2) == 0 &&
++		   (op3 & 0x20) == 0 && op4 == 2) {
++		/*
++		 * |------+-----+-----+--------+-----+------------------------------------|
++		 * | op0  | op1 | op2 |    op3 | op4 |                                    |
++		 * |------+-----+-----+--------+-----+------------------------------------|
++		 * | xx11 |   - |  0x | 0xxxxx |  10 | Load/store register (unprivileged) |
++		 * |------+-----+-----+--------+-----+------------------------------------|
++		 */
++		return align_ldst_unpriv(insn, regs);
++	} else
++		return 1;
++}
++
++int do_alignment_fixup(unsigned long addr, unsigned int esr,
++		       struct pt_regs *regs)
++{
++	u32 insn;
++	int res;
++
++	if (user_mode(regs)) {
++		__le32 insn_le;
++
++		if (!is_ttbr0_addr(addr))
++			return 1;
++
++		if (get_user(insn_le,
++			     (__le32 __user *)instruction_pointer(regs)))
++			return 1;
++		insn = le32_to_cpu(insn_le);
++	} else {
++		if (aarch64_insn_read((void *)instruction_pointer(regs), &insn))
++			return 1;
++	}
++
++	if (__aarch64_insn_is_class_ldst(insn))
++		res = align_ldst(insn, regs);
++	else if (__aarch64_insn_is_dc_zva(insn))
++		res = align_dc_zva(addr, regs);
++	else
++		res = 1;
++
++	if (!res) {
++		perf_sw_event(PERF_COUNT_SW_ALIGNMENT_FAULTS, 1, regs, regs->pc);
++		arm64_skip_faulting_instruction(regs, AARCH64_INSN_SIZE);
++	}
++	return res;
++}
+diff --git a/arch/arm64/mm/fault.c b/arch/arm64/mm/fault.c
+index 0b52557652be..6a6cc1b5127c 100644
+--- a/arch/arm64/mm/fault.c
++++ b/arch/arm64/mm/fault.c
+@@ -851,8 +851,9 @@ static int __kprobes do_translation_fault(unsigned long far,
+ static int do_alignment_fault(unsigned long far, unsigned long esr,
+ 			      struct pt_regs *regs)
+ {
+-	if (IS_ENABLED(CONFIG_COMPAT_ALIGNMENT_FIXUPS) &&
+-	    compat_user_mode(regs))
++	if (!compat_user_mode(regs))
++		return do_alignment_fixup(far, esr, regs);
++	else if (IS_ENABLED(CONFIG_COMPAT_ALIGNMENT_FIXUPS))
+ 		return do_compat_alignment_fixup(far, regs);
+ 	do_bad_area(far, esr, regs);
+ 	return 0;
+-- 
+2.55.0
+

--- a/v7.2/0002-ampere-arm64-Work-around-Ampere-Altra-erratum-82288-.patch
+++ b/v7.2/0002-ampere-arm64-Work-around-Ampere-Altra-erratum-82288-.patch
@@ -1,0 +1,207 @@
+From bf340084ac05b5b2b299e80b6d6cec823efb600d Mon Sep 17 00:00:00 2001
+From: D Scott Phillips <scott@os.amperecomputing.com>
+Date: Tue, 13 Feb 2024 11:08:06 -0800
+Subject: [PATCH 2/2] ampere/arm64: Work around Ampere Altra erratum #82288
+ PCIE_65
+
+Altra's PCIe controller may generate incorrect addresses when receiving
+writes from the CPU with a discontiguous set of byte enables. Attempt to
+work around this by handing out Device-nGnRE maps instead of Normal
+Non-cacheable maps for PCIe memory areas.
+
+Signed-off-by: D Scott Phillips <scott@os.amperecomputing.com>
+---
+ Documentation/arch/arm64/silicon-errata.rst |  2 ++
+ arch/arm64/Kconfig                          | 21 +++++++++++++++
+ arch/arm64/include/asm/pci.h                |  6 +++++
+ arch/arm64/include/asm/pgtable.h            | 26 ++++++++++++++----
+ arch/arm64/mm/ioremap.c                     | 30 +++++++++++++++++++++
+ drivers/pci/quirks.c                        | 11 ++++++++
+ 6 files changed, 91 insertions(+), 5 deletions(-)
+
+diff --git a/Documentation/arch/arm64/silicon-errata.rst b/Documentation/arch/arm64/silicon-errata.rst
+index 88b4aa45a206..0830d54b3d00 100644
+--- a/Documentation/arch/arm64/silicon-errata.rst
++++ b/Documentation/arch/arm64/silicon-errata.rst
+@@ -53,6 +53,8 @@ stable kernels.
+ | Allwinner      | A64/R18         | UNKNOWN1        | SUN50I_ERRATUM_UNKNOWN1     |
+ +----------------+-----------------+-----------------+-----------------------------+
+ +----------------+-----------------+-----------------+-----------------------------+
++| Ampere         | Altra           | #82288          | ALTRA_ERRATUM_82288         |
+++----------------+-----------------+-----------------+-----------------------------+
+ | Ampere         | AmpereOne       | AC03_CPU_38     | AMPERE_ERRATUM_AC03_CPU_38  |
+ +----------------+-----------------+-----------------+-----------------------------+
+ | Ampere         | AmpereOne       | AC03_CPU_57     | N/A                         |
+diff --git a/arch/arm64/Kconfig b/arch/arm64/Kconfig
+index b3afe0688919..1712672793df 100644
+--- a/arch/arm64/Kconfig
++++ b/arch/arm64/Kconfig
+@@ -456,6 +456,27 @@ config AMPERE_ERRATUM_AC04_CPU_23
+ config ARM64_WORKAROUND_CLEAN_CACHE
+ 	bool
+ 
++config ALTRA_ERRATUM_82288
++	bool "Ampere Altra: 82288: PCIE_65: PCIe Root Port outbound write combining issue"
++	default y
++	help
++	  This option adds an alternative code sequence to work around
++	  Ampere Altra erratum 82288.
++
++	  PCIe device drivers may map MMIO space as Normal, non-cacheable
++	  memory attribute (e.g. Linux kernel drivers mapping MMIO
++	  using ioremap_wc). This may be for the purpose of enabling write
++	  combining or unaligned accesses. This can result in data corruption
++	  on the PCIe interface’s outbound MMIO writes due to issues with the
++	  write-combining operation.
++
++	  The workaround modifies software that maps PCIe MMIO space as Normal,
++	  non-cacheable memory (e.g. ioremap_wc) to instead Device,
++	  non-gatheringmemory (e.g. ioremap). And all memory operations on PCIe
++	  MMIO space must be strictly aligned.
++
++	  If unsure, say Y.
++
+ config ARM64_ERRATUM_826319
+ 	bool "Cortex-A53: 826319: System might deadlock if a write cannot complete until read data is accepted"
+ 	default y
+diff --git a/arch/arm64/include/asm/pci.h b/arch/arm64/include/asm/pci.h
+index 016eb6b46dc0..edf663ec9f72 100644
+--- a/arch/arm64/include/asm/pci.h
++++ b/arch/arm64/include/asm/pci.h
+@@ -18,6 +18,12 @@
+ 
+ #define arch_can_pci_mmap_wc() 1
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++extern struct static_key_false have_altra_erratum_82288;
++
++bool is_pci_mmio(phys_addr_t phys_addr, size_t size);
++#endif
++
+ /* Generic PCI */
+ #include <asm-generic/pci.h>
+ 
+diff --git a/arch/arm64/include/asm/pgtable.h b/arch/arm64/include/asm/pgtable.h
+index 27689c62bd25..c02d5121f920 100644
+--- a/arch/arm64/include/asm/pgtable.h
++++ b/arch/arm64/include/asm/pgtable.h
+@@ -301,11 +301,6 @@ static inline pte_t pte_mkyoung(pte_t pte)
+ 	return set_pte_bit(pte, __pgprot(PTE_AF));
+ }
+ 
+-static inline pte_t pte_mkspecial(pte_t pte)
+-{
+-	return set_pte_bit(pte, __pgprot(PTE_SPECIAL));
+-}
+-
+ static inline pte_t pte_mkcont(pte_t pte)
+ {
+ 	return set_pte_bit(pte, __pgprot(PTE_CONT));
+@@ -769,6 +764,27 @@ static inline void __set_puds(struct mm_struct *mm, unsigned long addr,
+ 	__pgprot_modify(prot, PTE_ATTRINDX_MASK, \
+ 			PTE_ATTRINDX(MT_NORMAL_NC) | PTE_PXN | PTE_UXN)
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++extern struct static_key_false have_altra_erratum_82288;
++
++bool is_pci_mmio(phys_addr_t phys_addr, size_t size);
++#endif
++
++static inline pte_t pte_mkspecial(pte_t pte)
++{
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++	phys_addr_t phys = __pte_to_phys(pte);
++	pgprot_t prot = __pgprot(pte_val(pte) & ~__phys_to_pte_val(__pte_to_phys(__pte(~0ull))));
++
++	if (static_branch_unlikely(&have_altra_erratum_82288) &&
++	    is_pci_mmio(phys, PAGE_SIZE)) {
++		pte = __pte(__phys_to_pte_val(phys) | pgprot_val(pgprot_device(prot)));
++	}
++#endif
++
++	return set_pte_bit(pte, __pgprot(PTE_SPECIAL));
++}
++
+ #define __HAVE_PHYS_MEM_ACCESS_PROT
+ struct file;
+ extern pgprot_t phys_mem_access_prot(struct file *file, unsigned long pfn,
+diff --git a/arch/arm64/mm/ioremap.c b/arch/arm64/mm/ioremap.c
+index 6eef48ef6278..28d2e6e22fdb 100644
+--- a/arch/arm64/mm/ioremap.c
++++ b/arch/arm64/mm/ioremap.c
+@@ -2,6 +2,7 @@
+ 
+ #include <linux/mm.h>
+ #include <linux/io.h>
++#include <linux/pci.h>
+ 
+ static ioremap_prot_hook_t ioremap_prot_hook;
+ 
+@@ -14,6 +15,29 @@ int arm64_ioremap_prot_hook_register(ioremap_prot_hook_t hook)
+ 	return 0;
+ }
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++DEFINE_STATIC_KEY_FALSE(have_altra_erratum_82288);
++
++bool is_pci_mmio(phys_addr_t phys_addr, size_t size)
++{
++	struct pci_host_bridge *bridge;
++	struct resource_entry *entry;
++	struct resource res;
++	struct pci_bus *bus;
++
++	res = DEFINE_RES_MEM(phys_addr, size);
++	bus = NULL;
++	while ((bus = pci_find_next_bus(bus)) != NULL) {
++		bridge = to_pci_host_bridge(bus->bridge);
++		resource_list_for_each_entry(entry, &bridge->windows) {
++			if (resource_contains(entry->res, &res))
++				return true;
++		}
++	}
++	return false;
++}
++#endif
++
+ void __iomem *__ioremap_prot(phys_addr_t phys_addr, size_t size,
+ 			     pgprot_t pgprot)
+ {
+@@ -37,6 +61,12 @@ void __iomem *__ioremap_prot(phys_addr_t phys_addr, size_t size,
+ 		return NULL;
+ 	}
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++	if (static_branch_unlikely(&have_altra_erratum_82288) &&
++	    is_pci_mmio(phys_addr, size))
++		pgprot = pgprot_device(pgprot);
++#endif
++
+ 	return generic_ioremap_prot(phys_addr, size, pgprot);
+ }
+ EXPORT_SYMBOL(__ioremap_prot);
+diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
+index b09f27f7846f..8fed7861502f 100644
+--- a/drivers/pci/quirks.c
++++ b/drivers/pci/quirks.c
+@@ -6384,6 +6384,17 @@ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_XILINX, 0x5021, of_pci_make_dev_node);
+ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_REDHAT, 0x0005, of_pci_make_dev_node);
+ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_EFAR, 0x9660, of_pci_make_dev_node);
+ 
++#ifdef CONFIG_ALTRA_ERRATUM_82288
++static void quirk_altra_erratum_82288(struct pci_dev *dev)
++{
++	pr_info_once("Write combining PCI maps disabled due to hardware erratum\n");
++	static_branch_enable(&have_altra_erratum_82288);
++}
++DECLARE_PCI_FIXUP_EARLY(PCI_VENDOR_ID_AMPERE, 0xe100, quirk_altra_erratum_82288);
++static int setup_ampere_altra_pcie_65(char *) { quirk_altra_erratum_82288(NULL); return 0; }
++early_param("ampere_altra_pcie_65", setup_ampere_altra_pcie_65);
++#endif
++
+ /*
+  * Devices known to require a longer delay before first config space access
+  * after reset recovery or resume from D3cold:
+-- 
+2.55.0
+


### PR DESCRIPTION
Rebase of the erratum patches for kernel v7.2.

This branch stacks on #16: the v6.19.7 patches from that PR are the base for this rebase, and its commit is included here unchanged. Merging this would bring the repo up to date for both versions.

Changes needed for v7.2: patch 0001 conflicts in arch/arm64/kernel/Makefile, because v7.2 removed entry-fpsimd.o from the obj-y list. Resolved by adding alignment.o to the current v7.2 object list. No other changes; patch 0002 applies with fuzz only.

Compile-tested against v7.2 on an Ampere Altra system (aarch64, Fedora config with CONFIG_ALTRA_ERRATUM_82288=y): alignment.o, fault.o, ioremap.o and quirks.o all build without warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
